### PR TITLE
Update condition to enter new rounds as implemented

### DIFF
--- a/spec/consensus/consensus-paper/consensus.tex
+++ b/spec/consensus/consensus-paper/consensus.tex
@@ -140,7 +140,13 @@
 		\ENDUPON
 		
 		\SHORTSPACE 
-		\UPON{$f+1$ $\li{*,h_p,round, *, *}$ \textbf{with} $round > round_p$} 
+		\UPON{$2f+1$ $\li{\Prevote,h_p,round, *}$ \textbf{with} $round > round_p$} 
+		\label{line:tab:skipRounds} 
+			\STATE $StartRound(round)$ \label{line:tab:nextRound2} 
+		\ENDUPON
+		
+		\SHORTSPACE 
+		\UPON{$2f+1$ $\li{\Precommit,h_p,round, *}$ \textbf{with} $round > round_p$} 
 		\label{line:tab:skipRounds} 
 			\STATE $StartRound(round)$ \label{line:tab:nextRound2} 
 		\ENDUPON


### PR DESCRIPTION
Updating the paper with the specification for [exit conditions](https://github.com/tendermint/tendermint/blob/master/docs/spec/consensus/consensus.md#common-exit-conditions) and the corresponding implementation:
- [consensus/state.go:807](https://github.com/tendermint/tendermint/blob/b43da179583ef005acab32166a2922cb88ee3504/consensus/state.go#L807)
- [consensus/state.go:1761](https://github.com/tendermint/tendermint/blob/b43da179583ef005acab32166a2922cb88ee3504/consensus/state.go#L1761)
- [consensus/state.go:1783](https://github.com/tendermint/tendermint/blob/b43da179583ef005acab32166a2922cb88ee3504/consensus/state.go#L1783)
- [consensus/state.go:1794](https://github.com/tendermint/tendermint/blob/b43da179583ef005acab32166a2922cb88ee3504/consensus/state.go#L1794)

This is also related #46, where moving to future round with f+1 messages of any type can be problematic.