### PR TITLE
update link to the pex reactor

### DIFF
--- a/spec/p2p/peer.md
+++ b/spec/p2p/peer.md
@@ -2,7 +2,7 @@
 
 This document explains how Tendermint Peers are identified and how they connect to one another.
 
-For details on peer discovery, see the [peer exchange (PEX) reactor doc](https://github.com/tendermint/tendermint/blob/master/docs/spec/reactors/pex/pex.md).
+For details on peer discovery, see the [peer exchange (PEX) reactor doc](https://github.com/tendermint/spec/blob/master/spec/reactors/pex/pex.md).
 
 ## Peer Identity
 


### PR DESCRIPTION
old link in peer.md goes to 404 page, need to update it to point to the pex reactor in the spec repository