### PR TITLE
restore "document state sync ABCI interface and P2P protocol (#90)""

### DIFF
--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -436,11 +436,11 @@ via light client.
   - `AppHash ([]byte)`: The light client-verified app hash for this height, from the blockchain.
 - **Response**:
   - `Result (Result)`: The result of the snapshot offer.
-    - `accept`: Snapshot is accepted, start applying chunks.
-    - `abort`: Abort snapshot restoration, and don't try any other snapshots.
-    - `reject`: Reject this specific snapshot, try others.
-    - `reject_format`: Reject all snapshots with this `format`, try others.
-    - `reject_senders`: Reject all snapshots from all senders of this snapshot, try others.
+    - `ACCEPT`: Snapshot is accepted, start applying chunks.
+    - `ABORT`: Abort snapshot restoration, and don't try any other snapshots.
+    - `REJECT`: Reject this specific snapshot, try others.
+    - `REJECT_FORMAT`: Reject all snapshots with this `format`, try others.
+    - `REJECT_SENDERS`: Reject all snapshots from all senders of this snapshot, try others.
 - **Usage**:
   - `OfferSnapshot` is called when bootstrapping a node using state sync. The application may
     accept or reject snapshots as appropriate. Upon accepting, Tendermint will retrieve and
@@ -461,12 +461,12 @@ via light client.
   - `Sender (string)`: The P2P ID of the node who sent this chunk.
 - **Response**:
   - `Result (Result)`: The result of applying this chunk.
-    - `accept`: The chunk was accepted.
-    - `abort`: Abort snapshot restoration, and don't try any other snapshots.
-    - `retry`: Reapply this chunk, combine with `RefetchChunks` and `RejectSenders` as appropriate.
-    - `retry_snapshot`: Restart this snapshot from `OfferSnapshot`, reusing chunks unless 
+    - `ACCEPT`: The chunk was accepted.
+    - `ABORT`: Abort snapshot restoration, and don't try any other snapshots.
+    - `RETRY`: Reapply this chunk, combine with `RefetchChunks` and `RejectSenders` as appropriate.
+    - `RETRY_SNAPSHOT`: Restart this snapshot from `OfferSnapshot`, reusing chunks unless 
       instructed otherwise.
-    - `reject_snapshot`: Reject this snapshot, try a different one.
+    - `REJECT_SNAPSHOT`: Reject this snapshot, try a different one.
   - `RefetchChunks ([]uint32)`: Refetch and reapply the given chunks, regardless of `Result`. Only  
     the listed chunks will be refetched, and reapplied in sequential order.
   - `RejectSenders ([]string)`: Reject the given P2P senders, regardless of `Result`. Any chunks 

--- a/spec/abci/client-server.md
+++ b/spec/abci/client-server.md
@@ -85,7 +85,7 @@ it is the standard way to encode integers in Protobuf. It is also generally shor
 As noted above, this prefixing does not apply for GRPC.
 
 An ABCI server must also be able to support multiple connections, as
-Tendermint uses three connections.
+Tendermint uses four connections.
 
 ### Async vs Sync
 

--- a/spec/reactors/state_sync/reactor.md
+++ b/spec/reactors/state_sync/reactor.md
@@ -1,7 +1,7 @@
 # State Sync Reactor
 
 State sync allows new nodes to rapidly bootstrap and join the network by discovering, fetching,
-and restoring state machine snapshots. For more information, see the [state sync ABCI section](../abci/apps.md#state-sync).
+and restoring state machine snapshots. For more information, see the [state sync ABCI section](../../abci/apps.md#state-sync).
 
 The state sync reactor has two main responsibilites:
 
@@ -15,7 +15,7 @@ The state sync process for bootstrapping a new node is described in detail in th
 above. While technically part of the reactor (see `statesync/syncer.go` and related components), 
 this document will only cover the P2P reactor component.
 
-For details on the ABCI methods and data types, see the [ABCI documentation](../abci/abci.md).
+For details on the ABCI methods and data types, see the [ABCI documentation](../../abci/abci.md).
 
 ## State Sync P2P Protocol
 

--- a/spec/reactors/state_sync/reactor.md
+++ b/spec/reactors/state_sync/reactor.md
@@ -1,0 +1,77 @@
+# State Sync Reactor
+
+State sync allows new nodes to rapidly bootstrap and join the network by discovering, fetching,
+and restoring state machine snapshots. For more information, see the [state sync ABCI section](../abci/apps.md#state-sync).
+
+The state sync reactor has two main responsibilites:
+
+* Serving state machine snapshots taken by the local ABCI application to new nodes joining the 
+  network.
+
+* Discovering existing snapshots and fetching snapshot chunks for an empty local application
+  being bootstrapped.
+
+The state sync process for bootstrapping a new node is described in detail in the section linked
+above. While technically part of the reactor (see `statesync/syncer.go` and related components), 
+this document will only cover the P2P reactor component.
+
+For details on the ABCI methods and data types, see the [ABCI documentation](../abci/abci.md).
+
+## State Sync P2P Protocol
+
+When a new node begin state syncing, it will ask all peers it encounters if it has any
+available snapshots:
+
+```go
+type snapshotsRequestMessage struct{}
+```
+
+The receiver will query the local ABCI application via `ListSnapshots`, and send a message 
+containing snapshot metadata (limited to 4 MB) for each of the 10 most recent snapshots:
+
+```go
+type snapshotsResponseMessage struct {
+	Height   uint64
+	Format   uint32
+	Chunks   uint32
+	Hash     []byte
+	Metadata []byte
+}
+```
+
+The node running state sync will offer these snapshots to the local ABCI application via
+`OfferSnapshot` ABCI calls, and keep track of which peers contain which snapshots. Once a snapshot
+is accepted, the state syncer will request snapshot chunks from appropriate peers:
+
+```go
+type chunkRequestMessage struct {
+	Height uint64
+	Format uint32
+	Index  uint32
+}
+```
+
+The receiver will load the requested chunk from its local application via `LoadSnapshotChunk`,
+and respond with it (limited to 16 MB):
+
+```go
+type chunkResponseMessage struct {
+	Height  uint64
+	Format  uint32
+	Index   uint32
+	Chunk   []byte
+	Missing bool
+}
+```
+
+Here, `Missing` is used to signify that the chunk was not found on the peer, since an empty
+chunk is a valid (although unlikely) response. 
+
+The returned chunk is given to the ABCI application via `ApplySnapshotChunk` until the snapshot
+is restored. If a chunk response is not returned within some time, it will be re-requested,
+possibly from a different peer.
+
+The ABCI application is able to request peer bans and chunk refetching as part of the ABCI protocol.
+
+If no state sync is in progress (i.e. during normal operation), any unsolicited response messages 
+are discarded.


### PR DESCRIPTION
This PR restores @erikgrinaker's work from #90. From the original PR description:

```
The corresponding Tendermint PRs are tendermint/tendermint#4704 and tendermint/tendermint#4705.

We should probably add a guide that reads more like a hands-on tutorial as well, with actual commands and examples. I'll write this as part of the release package.
```