### PR TITLE
Update evidence params with MaxNum

### DIFF
--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -617,6 +617,7 @@ via light client.
     - In Cosmos-SDK based blockchains, `MaxAgeDuration` is usually equal to the
       unbonding period. `MaxAgeNumBlocks` is calculated by dividing the unboding
       period by the average block time (e.g. 2 weeks / 6s per block = 2d8h).
+  - `MaxNum (uint32)`: The maximum number of evidence that can be committed to a single block
 
 ### ValidatorParams
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -289,6 +289,15 @@ for it).
 
 Must have `MaxAgeNumBlocks > 0`.
 
+### EvidenceParams.MaxNum
+
+This is the maximum number of evidence that can be committed to a single block
+
+The product of this and the `MaxEvidenceBytes` must not exceed the size of 
+a block minus it's overhead ( ~ `MaxBytes`)
+
+The amount must be a positive number
+
 ### Updates
 
 The application may set the ConsensusParams during InitChain, and update them during

--- a/spec/abci/client-server.md
+++ b/spec/abci/client-server.md
@@ -35,7 +35,6 @@ appropriately (ie. to `socket` or `grpc`).
 See examples, in various stages of maintenance, in
 [Go](https://github.com/tendermint/tendermint/tree/master/abci/server),
 [JavaScript](https://github.com/tendermint/js-abci),
-[Python](https://github.com/tendermint/tendermint/tree/master/abci/example/python3/abci),
 [C++](https://github.com/mdyring/cpp-tmsp), and
 [Java](https://github.com/jTendermint/jabci).
 

--- a/spec/blockchain/state.md
+++ b/spec/blockchain/state.md
@@ -113,6 +113,7 @@ type BlockParams struct {
 type EvidenceParams struct {
 	MaxAgeNumBlocks int64
 	MaxAgeDuration  time.Duration
+    MaxNum          uint32
 }
 
 type ValidatorParams struct {

--- a/spec/blockchain/state.md
+++ b/spec/blockchain/state.md
@@ -107,13 +107,13 @@ func (params ConsensusParams) Hash() []byte {
 type BlockParams struct {
 	MaxBytes        int64
 	MaxGas          int64
-  TimeIotaMs      int64
+	TimeIotaMs      int64
 }
 
 type EvidenceParams struct {
 	MaxAgeNumBlocks int64
 	MaxAgeDuration  time.Duration
-    MaxNum          uint32
+	MaxNum          uint32
 }
 
 type ValidatorParams struct {


### PR DESCRIPTION
As part of [#2590](https://github.com/tendermint/tendermint/issues/2590)

Update usages of the evidence params to include the max number parameter which sets the maximum number of evidence that can be committed to a single block