### PR TITLE
spec: add ProofTrialPeriod to EvidenceParam

### DIFF
--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -618,6 +618,8 @@ via light client.
       unbonding period. `MaxAgeNumBlocks` is calculated by dividing the unboding
       period by the average block time (e.g. 2 weeks / 6s per block = 2d8h).
   - `MaxNum (uint32)`: The maximum number of evidence that can be committed to a single block
+  - `ProofTrialPeriod (int64)`: The duration in terms of blocks that an indicted node has to
+      provide proof of correctly executing a lock change in the event of amnesia evidence. 
 
 ### ValidatorParams
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -291,20 +291,20 @@ Must have `MaxAgeNumBlocks > 0`.
 
 ### EvidenceParams.MaxNum
 
-This is the maximum number of evidence that can be committed to a single block
+This is the maximum number of evidence that can be committed to a single block.
 
 The product of this and the `MaxEvidenceBytes` must not exceed the size of 
-a block minus it's overhead ( ~ `MaxBytes`)
+a block minus it's overhead ( ~ `MaxBytes`).
 
-The amount must be a positive number
+The amount must be a positive number.
 
 ### EvidenceParams.ProofTrialPeriod
 
 This is the duration in terms of blocks that an indicted validator has to prove a 
 correct lock change in the event of amnesia evidence when a validator voted more
-than once across different rounds
+than once across different rounds.
 
-This must be positive and less then `EvidenceParams.MaxAgeNumBlocks`
+This must be positive and less then `EvidenceParams.MaxAgeNumBlocks`.
 
 ### Updates
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -298,6 +298,14 @@ a block minus it's overhead ( ~ `MaxBytes`)
 
 The amount must be a positive number
 
+### EvidenceParams.ProofTrialPeriod
+
+This is the duration in terms of blocks that an indicted validator has to prove a 
+correct lock change in the event of amnesia evidence when a validator voted more
+than once across different rounds
+
+This must be positive and less then `EvidenceParams.MaxAgeNumBlocks`
+
 ### Updates
 
 The application may set the ConsensusParams during InitChain, and update them during

--- a/spec/blockchain/state.md
+++ b/spec/blockchain/state.md
@@ -111,9 +111,10 @@ type BlockParams struct {
 }
 
 type EvidenceParams struct {
-	MaxAgeNumBlocks int64
-	MaxAgeDuration  time.Duration
-	MaxNum          uint32
+    MaxAgeNumBlocks   int64
+	MaxAgeDuration    time.Duration
+    MaxNum            uint32
+    ProofTrialPeriod  int64
 }
 
 type ValidatorParams struct {

--- a/spec/blockchain/state.md
+++ b/spec/blockchain/state.md
@@ -112,7 +112,7 @@ type BlockParams struct {
 
 type EvidenceParams struct {
     MaxAgeNumBlocks   int64
-	MaxAgeDuration    time.Duration
+    MaxAgeDuration    time.Duration
     MaxNum            uint32
     ProofTrialPeriod  int64
 }


### PR DESCRIPTION
Following from the amnesia PR is the introduction of the `ProofTrialPeriod` which is a parameter that dictates the duration (in blocks) that a indicted validator has to submit proof of a correct lock change which arises in the event of amnesia evidence 