### PR TITLE
update spec with the removal of phantom validator evidence

### DIFF
--- a/spec/consensus/light-client/accountability.md
+++ b/spec/consensus/light-client/accountability.md
@@ -311,10 +311,10 @@ Consequences:
 **Remark.** We can have phantom-validator-based attacks as a follow up of equivocation or amnesia based attack where forked state contains validators that are not part of the validator set at the main chain. In this case, they keep signing messages contributed to a forked chain (the wrong branch) although they are not part of the validator set on the main chain. This attack can also be used to attack full node during a period of time it is eclipsed.
 
 **Remark.** Phantom validator evidence has been removed from implementation as it was deemed, although possibly a plausible form of evidence, not relevant. Any attack on
-the light client involving a phantom validator will have needed to be aided by 1/3+ lunatic
+the light client involving a phantom validator will have needed to be initiated by 1/3+ lunatic
 validators that can forge a new validator set that includes the phantom validator. Only in
 that case will the light client accept the phantom validators vote. We need only worry about
-punishing the 1/3+ lunatic cabal. 
+punishing the 1/3+ lunatic cabal, that is the root cause of the attack. 
 
 ### Lunatic validator
 

--- a/spec/consensus/light-client/accountability.md
+++ b/spec/consensus/light-client/accountability.md
@@ -310,6 +310,12 @@ Consequences:
 
 **Remark.** We can have phantom-validator-based attacks as a follow up of equivocation or amnesia based attack where forked state contains validators that are not part of the validator set at the main chain. In this case, they keep signing messages contributed to a forked chain (the wrong branch) although they are not part of the validator set on the main chain. This attack can also be used to attack full node during a period of time it is eclipsed.
 
+**Remark.** Phantom validator evidence has been removed from implementation as it was deemed, although possibly a plausible form of evidence, not relevant. Any attack on
+the light client involving a phantom validator will have needed to be aided by 1/3+ lunatic
+validators that can forge a new validator set that includes the phantom validator. Only in
+that case will the light client accept the phantom validators vote. We need only worry about
+punishing the 1/3+ lunatic cabal. 
+
 ### Lunatic validator
 
 Lunatic validator agrees to sign commit messages for arbitrary application state. It is used to attack light clients.

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -236,7 +236,7 @@ type DuplicateVoteEvidence struct {
 `AmnesiaEvidence` represents a validator that has incorrectly voted for another block in a 
 different round to the the block that the validator was previously locked on. This form
 of evidence is generated differently from the rest. See this 
-[ADR](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-056-proving-amnesia-attacks.md).
+[ADR](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-056-proving-amnesia-attacks.md) for more information.
 
 ```go
 type AmnesiaEvidence struct {
@@ -253,18 +253,6 @@ type LunaticValidatorEvidence struct {
 	Header             *Header 
 	Vote               *Vote  
 	InvalidHeaderField string
-}
-```
-
-`PhantomValidatorEvidence` represents a validator that has signed for a block where it was not part of the validator set. 
-This attack also only applies to Light clients. Phantom validators must still be staked. `LastHeightValidatorWasInSet` 
-indicated the height that they last voted.
-
-
-```go
-type PhantomValidatorEvidence struct {
-	Vote                        *Vote 
-	LastHeightValidatorWasInSet int64
 }
 ```
 


### PR DESCRIPTION
As per [\#5168](https://github.com/tendermint/tendermint/issues/5168) we have removed phantom validator evidence as it has been deemed unnecessary. This PR makes the corresponding changes to the spec