### PR TITLE
add a stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: "This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions."
+          days-before-stale: 30
+          days-before-close: 6
+          exempt-pr-labels: "pinned, proposal"


### PR DESCRIPTION
This bot runs every evening and will mark PRs that have been open and not worked on for 30 days, after 6 days from being marked if they have not been worked on then the bot will automatically close them. 

To avoid the closing you add the label `S:pinned` (will be created) and the bot will avoid it.