### PR TITLE
evidence: update data structures

### DIFF
--- a/rust-spec/lightclient/verification/verification.md
+++ b/rust-spec/lightclient/verification/verification.md
@@ -1147,16 +1147,16 @@ func Main (primary PeerID, lightStore LightStore, targetHeight Height)
 [TMBC-SOUND-DISTR-POSS-COMMIT-link]: #tmbc-sound-distr-poss-commit1
 
 [lightclient]: https://github.com/interchainio/tendermint-rs/blob/e2cb9aca0b95430fca2eac154edddc9588038982/docs/architecture/adr-002-lite-client.md
-[fork-detector]: https://github.com/informalsystems/tendermint-rs/blob/master/docs/spec/lightclient/detection.md
-[fullnode]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md
+[fork-detector]: https://github.com/tendermint/spec/blob/master/rust-spec/lightclient/detection/detection_001_reviewed.md
+<!-- [fullnode]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md -->
 
 [ibc-rs]:https://github.com/informalsystems/ibc-rs
 
-[FN-LuckyCase-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-luckycase
+<!-- [FN-LuckyCase-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-luckycase -->
 
 [blockchain-validator-set]: https://github.com/tendermint/spec/blob/master/spec/blockchain/blockchain.md#data-structures
-[fullnode-data-structures]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#data-structures
+[fullnode-data-structures]: https://github.com/tendermint/spec/blob/master/spec/core/data_structures.md
 
-[FN-ManifestFaulty-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-manifestfaulty
+<!-- [FN-ManifestFaulty-link]: https://github.com/tendermint/spec/blob/master/spec/blockchain/fullnode.md#fn-manifestfaulty -->
 
 [arXiv]: https://arxiv.org/abs/1807.04938

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -115,7 +115,8 @@ enum EvidenceType {
 ```
 
 There are two forms of evidence: Duplicate Vote and Light Client Attack. More
-information can be found [here](https://github.com/tendermint/spec/blob/master/spec/light-client/accountability.md)
+information can be found in either [data structures](https://github.com/tendermint/spec/blob/master/spec/core/data_structures.md)
+or [accountability](https://github.com/tendermint/spec/blob/master/spec/light-client/accountability.md)
 
 ## Determinism
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -345,14 +345,6 @@ a block minus it's overhead ( ~ `MaxBytes`).
 
 The amount must be a positive number.
 
-### EvidenceParams.ProofTrialPeriod
-
-This is the duration in terms of blocks that an indicted validator has to prove a
-correct lock change in the event of amnesia evidence when a validator voted more
-than once across different rounds.
-
-This must be positive and less then `EvidenceParams.MaxAgeNumBlocks`.
-
 ### Updates
 
 The application may set the ConsensusParams during InitChain, and update them during

--- a/spec/consensus/creating-proposal.md
+++ b/spec/consensus/creating-proposal.md
@@ -17,7 +17,7 @@ we account for amino overhead for each transaction.
 ```go
 func MaxDataBytes(maxBytes int64, valsCount, evidenceCount int) int64 {
  return maxBytes -
-  MaxAminoOverheadForBlock -
+  MaxOverheadForBlock -
   MaxHeaderBytes -
   int64(valsCount)*MaxVoteBytes -
   int64(evidenceCount)*MaxEvidenceBytes
@@ -28,15 +28,13 @@ func MaxDataBytes(maxBytes int64, valsCount, evidenceCount int) int64 {
 
 Before we accept a transaction in the mempool, we check if it's size is no more
 than {MaxDataSize}. {MaxDataSize} is calculated using the same formula as
-above, except because the evidence size is unknown at the moment, we subtract
-maximum evidence size (1/10th of the maximum block size).
+above, except we subtract the max number of evidence, {MaxNum} by the maximum size of evidence
 
 ```go
 func MaxDataBytesUnknownEvidence(maxBytes int64, valsCount int) int64 {
  return maxBytes -
-  MaxAminoOverheadForBlock -
+  MaxOverheadForBlock -
   MaxHeaderBytes -
-  int64(valsCount)*MaxVoteBytes -
-  MaxEvidenceBytesPerBlock(maxBytes)
+  (maxNumEvidence * MaxEvidenceBytes)
 }
 ```

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -4,14 +4,14 @@ Here we describe the data structures in the Tendermint blockchain and the rules 
 
 The Tendermint blockchains consists of a short list of basic data types:
 
-- `Block`
-- `Header`
-- `Version`
-- `BlockID`
-- `Time`
-- `Data` (for transactions)
-- `Commit` and `Vote`
-- `EvidenceData` and `Evidence`
+-   `Block`
+-   `Header`
+-   `Version`
+-   `BlockID`
+-   `Time`
+-   `Data` (for transactions)
+-   `Commit` and `Vote`
+-   `EvidenceData` and `Evidence`
 
 ## Block
 
@@ -207,15 +207,10 @@ It is implemented as the following interface.
 ```go
 type Evidence interface {
  Height() int64                                     // height of the equivocation
- Time() time.Time                                   // time of the equivocation
- Address() []byte                                   // address of the equivocating validator
  Bytes() []byte                                     // bytes which comprise the evidence
- Hash() []byte                                      // hash of the evidence
- Verify(chainID string, pubKey crypto.PubKey) error // verify the evidence
- Equal(Evidence) bool                               // check equality of evidence
-
- ValidateBasic() error
- String() string
+ Hash() []byte                                      // hash of the evidence (this is also used for equality)
+ ValidateBasic() error                              // consistency check of the data
+ String() string                                    // string representation of the evidence
 }
 ```
 
@@ -231,24 +226,46 @@ in the same round of the same height. Votes are lexicographically sorted on `Blo
 
 ```go
 type DuplicateVoteEvidence struct {
- VoteA  *Vote
- VoteB  *Vote
-
- Timestamp time.Time
+    VoteA  *Vote
+    VoteB  *Vote
 }
 ```
 
 Valid Duplicate Vote Evidence must adhere to the following rules:
 
-- Validator Address, Height, Round and Type of vote must be the same for both votes
+-   Validator Address, Height, Round and Type must be the same for both votes
 
-- BlockID must be different for both votes (BlockID can be for a nil block)
+-   BlockID must be different for both votes (BlockID can be for a nil block)
 
-- Validator must have been in the validator set at that height
+-   Validator must have been in the validator set at that height
 
-- Vote signature must be valid (using the chainID)
+-   Vote signature must be valid (using the chainID)
 
-- Time must be equal to the block time
+-   Evidence must not have expired: either age in terms of height or time must be
+    less than the age stated in the consensus params. Time is the block time that the
+    votes were a part of.
+
+### LightClientAttackEvidence
+
+```go
+type LightClientAttackEvidence struct {
+	ConflictingBlock *LightBlock
+	CommonHeight     int64
+}
+```
+
+Valid Light Client Attack Evidence encompasses three types of attack and must adhere to the following rules
+
+-   If the header of the light block is invalid, thus indicating a lunatic attack, the node must check that
+    they can use `verifySkipping` from their header at the common height to the conflicting header
+
+-   If the header is valid, then the validator sets are the same and this is either a form of equivocation
+    or amnesia. We therefore check that 2/3 of the validator set also signed the conflicting header
+
+-   The trusted header of the node at the same height as the conflicting header must have a different hash to
+    the conflicting header.
+
+-   Evidence must not have expired. The height (and thus the time) is taken from the common height.
 
 ## Validation
 

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -4,14 +4,14 @@ Here we describe the data structures in the Tendermint blockchain and the rules 
 
 The Tendermint blockchains consists of a short list of basic data types:
 
--   `Block`
--   `Header`
--   `Version`
--   `BlockID`
--   `Time`
--   `Data` (for transactions)
--   `Commit` and `Vote`
--   `EvidenceData` and `Evidence`
+- `Block`
+- `Header`
+- `Version`
+- `BlockID`
+- `Time`
+- `Data` (for transactions)
+- `Commit` and `Vote`
+- `EvidenceData` and `Evidence`
 
 ## Block
 
@@ -233,15 +233,15 @@ type DuplicateVoteEvidence struct {
 
 Valid Duplicate Vote Evidence must adhere to the following rules:
 
--   Validator Address, Height, Round and Type must be the same for both votes
+- Validator Address, Height, Round and Type must be the same for both votes
 
--   BlockID must be different for both votes (BlockID can be for a nil block)
+- BlockID must be different for both votes (BlockID can be for a nil block)
 
--   Validator must have been in the validator set at that height
+- Validator must have been in the validator set at that height
 
--   Vote signature must be valid (using the chainID)
+- Vote signature must be valid (using the chainID)
 
--   Evidence must not have expired: either age in terms of height or time must be
+- Evidence must not have expired: either age in terms of height or time must be
     less than the age stated in the consensus params. Time is the block time that the
     votes were a part of.
 
@@ -249,23 +249,23 @@ Valid Duplicate Vote Evidence must adhere to the following rules:
 
 ```go
 type LightClientAttackEvidence struct {
-	ConflictingBlock *LightBlock
-	CommonHeight     int64
+ ConflictingBlock *LightBlock
+ CommonHeight     int64
 }
 ```
 
 Valid Light Client Attack Evidence encompasses three types of attack and must adhere to the following rules
 
--   If the header of the light block is invalid, thus indicating a lunatic attack, the node must check that
+- If the header of the light block is invalid, thus indicating a lunatic attack, the node must check that
     they can use `verifySkipping` from their header at the common height to the conflicting header
 
--   If the header is valid, then the validator sets are the same and this is either a form of equivocation
+- If the header is valid, then the validator sets are the same and this is either a form of equivocation
     or amnesia. We therefore check that 2/3 of the validator set also signed the conflicting header
 
--   The trusted header of the node at the same height as the conflicting header must have a different hash to
+- The trusted header of the node at the same height as the conflicting header must have a different hash to
     the conflicting header.
 
--   Evidence must not have expired. The height (and thus the time) is taken from the common height.
+- Evidence must not have expired. The height (and thus the time) is taken from the common height.
 
 ## Validation
 


### PR DESCRIPTION
Updated the data structures and other areas of the spec to reflect the go implementation.

Question: what do we want to do about the evidence reactor part in the spec. At the moment, it is almost blank