### PR TITLE
Describe valset sorting according to v0.34 requirements

### DIFF
--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -374,7 +374,8 @@ block.ValidatorsHash == MerkleRoot(state.Validators)
 
 MerkleRoot of the current validator set that is committing the block.
 This can be used to validate the `LastCommit` included in the next block.
-Note the validators are sorted by their voting power before computing the MerkleRoot.
+Note that before computing the MerkleRoot the validators are sorted 
+first by voting power (descending), then by address (ascending).
 
 ### NextValidatorsHash
 
@@ -385,7 +386,9 @@ block.NextValidatorsHash == MerkleRoot(state.NextValidators)
 MerkleRoot of the next validator set that will be the validator set that commits the next block.
 This is included so that the current validator set gets a chance to sign the
 next validator sets Merkle root.
-Note the validators are sorted by their voting power before computing the MerkleRoot.
+Note that before computing the MerkleRoot the validators are sorted 
+first by voting power (descending), then by address (ascending).
+
 
 ### ConsensusHash
 


### PR DESCRIPTION
closes #168 wrt. the datastructures documentation.

The [tendermint-rpc](https://docs.tendermint.com/master/rpc/#/Info/validators) documentation still needs to be taken care of; will be grateful if someone could point out what needs to be updated for that.