### PR TITLE
Introduce BlockGasUsed

### DIFF
--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -354,6 +354,7 @@ via light client.
     be non-deterministic.
     - `GasWanted (int64)`: Amount of gas requested for transaction.
     - `GasUsed (int64)`: Amount of gas consumed by transaction.
+    - `BlockGasUsed (int64)`: The total amount of gas consumed in the block after processing the transaction.
     - `Events ([]abci.Event)`: Type & Key-Value events for indexing
     transactions (eg. by account).
     - `Codespace (string)`: Namespace for the `Code`.
@@ -382,6 +383,7 @@ via light client.
     be non-deterministic.
     - `GasWanted (int64)`: Amount of gas requested for transaction.
     - `GasUsed (int64)`: Amount of gas consumed by transaction.
+    - `BlockGasUsed (int64)`: The total amount of gas consumed in the block after processing the transaction.
     - `Events ([]abci.Event)`: Type & Key-Value events for indexing
     transactions (eg. by account).
     - `Codespace (string)`: Namespace for the `Code`.

--- a/spec/core/state.md
+++ b/spec/core/state.md
@@ -68,11 +68,19 @@ message ResponseDeliverTx {
   repeated Event events     = 7
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
   string codespace = 8;
+  int64          block_gas_used = 9;
 }
 ```
 
 `ResponseDeliverTx` is the result of executing a transaction against the application.
-It returns a result code (`uint32`), an arbitrary byte array (`[]byte`) (ie. a return value), Log (`string`), Info (`string`), GasWanted (`int64`), GasUsed (`int64`), Events (`[]Events`) and a Codespace (`string`).
+It returns a result code (`uint32`), an arbitrary byte array (`[]byte`) (ie. a return value),
+Log (`string`), Info (`string`), GasWanted (`int64`), GasUsed (`int64`), Events (`[]Events`)
+and a Codespace (`string`).
+
+Note, the GasUsed field is useful information when diagnosing why a transaction
+failed and can be useful even information even when transaction succeeds. Whereas
+the BlockGasUsed reflects the total amount of gas used in the entire block during
+execution.
 
 ### Validator
 


### PR DESCRIPTION
Add `block_gas_used` of type `int64` to the documented `ResponseDeliverTx` in the spec.

go-impl: https://github.com/tendermint/tendermint/pull/5613
closes: #196