### PR TITLE
non-critical bugfix in the TLA+ spec (found by new version of apalache)

### DIFF
--- a/rust-spec/tendermint-accountability/TendermintAcc_004_draft.tla
+++ b/rust-spec/tendermint-accountability/TendermintAcc_004_draft.tla
@@ -332,7 +332,7 @@ OnQuorumOfNilPrevotes(p) ==
     /\ Cardinality(PV) >= THRESHOLD2 \* line 36
     /\ evidence' = PV \union evidence
     /\ BroadcastPrecommit(p, round[p], Id(NilValue))
-    /\ step' = [step EXCEPT ![p] = "PREVOTE"]
+    /\ step' = [step EXCEPT ![p] = "PRECOMMIT"]
     /\ UNCHANGED <<round, lockedValue, lockedRound, validValue,
                   validRound, decision, msgsPropose, msgsPrevote>>
     /\ action' = "OnQuorumOfNilPrevotes"


### PR DESCRIPTION
The new version of apalache has found a bug by checking the inductive invariant, which has not been uncovered by the old version. The bug does not affect safety and accountability.