### PR TITLE
genesis: remove app_hash 

### DIFF
--- a/spec/core/genesis.md
+++ b/spec/core/genesis.md
@@ -28,7 +28,5 @@ The genesis file is the starting point of a chain. An application will populate 
 
 - `validators`
     - This is an array of validators. This validator set is used as the starting validator set of the chain. This field can be empty, if the application sets the validator set in `InitChain`.
-  
-- `app_hash`: The applications state root hash. This field does not need to be populated at the start of the chain, the application may provide the needed information via `Initchain`.
 
 - `app_state`: This section is filled in by the application and is unknown to Tendermint.


### PR DESCRIPTION
## Description

Remove app_hash from genesis as it is not used and returned by the app on initchain. 

