### PR TITLE
rpc: Add totalGasUSed to block_results response

### DIFF
--- a/spec/rpc/README.md
+++ b/spec/rpc/README.md
@@ -592,6 +592,7 @@ curl -X POST https://localhost:26657 -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\
   "id": 0,
   "result": {
     "height": "12",
+    "total_gas_used": "100",
     "txs_results": [
       {
         "code": "0",


### PR DESCRIPTION
Add `total_gas_used` to `block_results` based on [this](https://github.com/tendermint/tendermint/pull/6615) PR