### PR TITLE
statesync: new messages for gossiping consensus params

### DIFF
--- a/proto/statesync/types.proto
+++ b/proto/statesync/types.proto
@@ -13,6 +13,8 @@ message Message {
     ChunkResponse      chunk_response       = 4;
     LightBlockRequest  light_block_request  = 5;
     LightBlockResponse light_block_response = 6;
+    ParamsRequest      params_request       = 7;
+    ParamsResponse     params_response      = 8;
   }
 }
 
@@ -46,4 +48,13 @@ message LightBlockRequest {
 
 message LightBlockResponse {
   tendermint.types.LightBlock light_block = 1;
+}
+
+message ParamsRequest {
+  uint64 height = 1;
+}
+
+message ParamsResponse {
+  uint64 height = 1;
+  tendermint.types.ConsensusParams consensus_params = 2;
 }

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -33,10 +33,10 @@ The Tendermint blockchains consists of a short list of data types:
   - [Address](#address)
   - [ConsensusParams](#consensusparams)
     - [BlockParams](#blockparams)
-  - [EvidenceParams](#evidenceparams)
-  - [ValidatorParams](#validatorparams)
-  - [VersionParams](#versionparams)
-    - [Proof](#proof)
+    - [EvidenceParams](#evidenceparams)
+    - [ValidatorParams](#validatorparams)
+    - [VersionParams](#versionparams)
+  - [Proof](#proof)
 
 
 ## Block
@@ -426,7 +426,7 @@ func SumTruncated(bz []byte) []byte {
 | max_bytes    | int64 | Max size of a block, in bytes.                                                                                                                                                                              | 1            |
 | max_gas      | int64 | Max sum of `GasWanted` in a proposed block. NOTE: blocks that violate this may be committed if there are Byzantine proposers. It's the application's responsibility to handle this when processing a block! | 2            |
 
-## EvidenceParams
+### EvidenceParams
 
 | Name               | Type                                                                                                                               | Description                                                                                                                                                                                                                                                                    | Field Number |
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
@@ -434,19 +434,19 @@ func SumTruncated(bz []byte) []byte {
 | max_age_duration   | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Max age of evidence, in time. It should correspond with an app's "unbonding period" or other similar mechanism for handling [Nothing-At-Stake attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed). | 2            |
 | max_bytes          | int64                                                                                                                              | maximum size in bytes of total evidence allowed to be entered into a block                                                                                                                                                                                                     | 3            |
 
-## ValidatorParams
+### ValidatorParams
 
 | Name          | Type            | Description                                                           | Field Number |
 |---------------|-----------------|-----------------------------------------------------------------------|--------------|
 | pub_key_types | repeated string | List of accepted public key types. Uses same naming as `PubKey.Type`. | 1            |
 
-## VersionParams
+### VersionParams
 
 | Name        | Type   | Description                   | Field Number |
 |-------------|--------|-------------------------------|--------------|
 | app_version | uint64 | The ABCI application version. | 1            |
 
-### Proof
+## Proof
 
 | Name      | Type           | Description                                   | Field Number |
 |-----------|----------------|-----------------------------------------------|--------------|

--- a/spec/p2p/messages/state-sync.md
+++ b/spec/p2p/messages/state-sync.md
@@ -119,7 +119,7 @@ A reciever to the request will use the state store to fetch the consensus params
 
 ### Message
 
-Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buffers/docs/proto#oneof). The `oneof` consists of six messages.
+Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buffers/docs/proto#oneof). The `oneof` consists of eight messages.
 
 | Name                 | Type                                       | Description                                  | Field Number |
 |----------------------|--------------------------------------------|----------------------------------------------|--------------|

--- a/spec/p2p/messages/state-sync.md
+++ b/spec/p2p/messages/state-sync.md
@@ -13,6 +13,7 @@ State sync has three distinct channels. The channel identifiers are listed below
 | SnapshotChannel   | 96     |
 | ChunkChannel      | 97     |
 | LightBlockChannel | 98     |
+| ParamsChannel     | 99     |
 
 ## Message Types
 
@@ -82,13 +83,13 @@ light blocks at specified heights.
 
 ### LightBlockResponse
 
-The sender will retrieve and construct the light block from both the block and state stores. The
+The receiver will retrieve and construct the light block from both the block and state stores. The
 receiver will verify the data by comparing the hashes and store the header, commit and validator set
 if necessary. The light block at the height of the snapshot will be used to verify the `AppHash`.
 
 | Name          | Type                                                    | Description                          | Field Number |
 |---------------|---------------------------------------------------------|--------------------------------------|--------------|
-| light_block   | [LightBlock](../../core/data_structures.md#lightblock)  | light block at the height requested  | 1            |
+| light_block   | [LightBlock](../../core/data_structures.md#lightblock)  | Light block at the height requested  | 1            |
 
 State sync will use [light client verification](../../light-client/verification.README.md) to verify
 the light blocks.
@@ -96,6 +97,25 @@ the light blocks.
 
 If no state sync is in progress (i.e. during normal operation), any unsolicited response messages
 are discarded.
+
+### ParamsRequest
+
+In order to build tendermint state, the state provider will request the params at the height of the snapshot and use the header to verify it.
+
+| Name     | Type   | Description                | Field Number |
+|----------|--------|----------------------------|--------------|
+| height   | uint64 | Height of the consensus params  | 1            |
+
+
+### ParamsResponse
+
+A reciever to the request will use the state store to fetch the consensus params at that height and return it to the sender.
+
+| Name     | Type   | Description                     | Field Number |
+|----------|--------|---------------------------------|--------------|
+| height   | uint64 | Height of the consensus params  | 1            |
+| consensus_params | [ConsensusParams](../../core/data_structures.md#ConsensusParams) | Consensus params at the height requested | 2 |
+
 
 ### Message
 
@@ -109,3 +129,5 @@ Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buff
 | chunk_response       | [ChunkRequest](#chunkresponse)             | Response of chunks used to recreate state.   | 4            |
 | light_block_request  | [LightBlockRequest](#lightblockrequest)    | Request a light block.                       | 5            |
 | light_block_response | [LightBlockResponse](#lightblockresponse)  | Respond with a light block                   | 6            |
+| params_request  | [ParamsRequest](#paramsrequest)    | Request the consensus params at a height.                       | 7            |
+| params_response | [ParamsResponse](#paramsresponse)  | Respond with the consensus params                   | 8            |

--- a/spec/p2p/messages/state-sync.md
+++ b/spec/p2p/messages/state-sync.md
@@ -6,7 +6,7 @@ order: 5
 
 ## Channels
 
-State sync has three distinct channels. The channel identifiers are listed below.
+State sync has four distinct channels. The channel identifiers are listed below.
 
 | Name              | Number |
 |-------------------|--------|


### PR DESCRIPTION
To be able to run state sync purely through p2p, the state provider, which has the responsibility of building and verifying tendermint state requires the ability to fetch consensus params. This PR introduces the messages needed. 