### PR TITLE
apps.md fixups

### DIFF
--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -92,13 +92,12 @@ to sequentially process pending transactions in the mempool that have
 not yet been committed. It should be initialized to the latest committed state
 at the end of every `Commit`.
 
+Before calling `Commit`, Tendermint will lock and flush the mempool connection,
+ensuring that all existing CheckTx are responded to and no new ones can begin.
 The `CheckTxState` may be updated concurrently with the `DeliverTxState`, as
-messages may be sent concurrently on the Consensus and Mempool connections. However,
-before calling `Commit`, Tendermint will lock and flush the mempool connection,
-ensuring that all existing CheckTx are responded to and no new ones can
-begin.
+messages may be sent concurrently on the Consensus and Mempool connections.
 
-After `Commit`, CheckTx is run again on all transactions that remain in the
+After `Commit`, while still holding the mempool lock, CheckTx is run again on all transactions that remain in the
 node's local mempool after filtering those included in the block.
 An additional `Type` parameter is made available to the CheckTx function that
 indicates whether an incoming transaction is new (`CheckTxType_New`), or a
@@ -135,7 +134,7 @@ It should always contain the latest committed state associated with the
 latest committed block.
 
 `QueryState` should be set to the latest `DeliverTxState` at the end of every `Commit`,
-ie. after the full block has been processed and the state committed to disk.
+after the full block has been processed and the state committed to disk.
 Otherwise it should never be modified.
 
 Tendermint Core currently uses the Query connection to filter peers upon
@@ -236,7 +235,7 @@ Both the `Code` and `Data` are included in a structure that is hashed into the
 the transaction by. This allows transactions to be queried according to what
 events took place during their execution.
 
-## Updating The Validator Set
+## Updating the Validator Set
 
 The application may set the validator set during InitChain, and may update it during
 EndBlock.
@@ -672,7 +671,7 @@ bootstrapping the node (e.g. chain ID, consensus parameters, validator sets, and
 from the genesis file and light client RPC servers. It also fetches and records the `AppVersion`
 from the ABCI application.
 
-Once the state machine has been restored and Tendermint has retrieved has gathered this additional
+Once the state machine has been restored and Tendermint has gathered this additional
 information, it transitions to block sync (if enabled) to fetch any remaining blocks up the chain
 head, and then transitions to regular consensus operation. At this point the node operates like
 any other node, apart from having a truncated block history at the height of the restored snapshot.

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -243,9 +243,9 @@ Both the `Code` and `Data` are included in a structure that is hashed into the
 the transaction by. This allows transactions to be queried according to what
 events took place during their execution.
 
-## Validator Updates
+## Updating The Validator Set
 
-The application may set the validator set during InitChain, and update it during
+The application may set the validator set during InitChain, and may update it during
 EndBlock.
 
 Note that the maximum total power of the validator set is bounded by
@@ -254,16 +254,16 @@ they do not make changes to the validator set that cause it to exceed this
 limit.
 
 Additionally, applications must ensure that a single set of updates does not contain any duplicates -
-a given public key can only appear in an update once. If an update includes
+a given public key can only appear once within a given update. If an update includes
 duplicates, the block execution will fail irrecoverably.
 
 ### InitChain
 
-ResponseInitChain can return a list of validators.
+The `InitChain` method can return a list of validators.
 If the list is empty, Tendermint will use the validators loaded in the genesis
 file.
-If the list is not empty, Tendermint will use it for the validator set.
-This way the application can determine the initial validator set for the
+If the list returned by `InitChain` is not empty, Tendermint will use its contents as the validator set.
+This way the application can set the initial validator set for the
 blockchain.
 
 ### EndBlock
@@ -312,14 +312,14 @@ evidence. They can be set in InitChain and updated in EndBlock.
 The maximum size of a complete Protobuf encoded block.
 This is enforced by Tendermint consensus.
 
-This implies a maximum tx size that is this MaxBytes, less the expected size of
+This implies a maximum transaction size that is this MaxBytes, less the expected size of
 the header, the validator set, and any included evidence in the block.
 
 Must have `0 < MaxBytes < 100 MB`.
 
 ### BlockParams.MaxGas
 
-The maximum of the sum of `GasWanted` in a proposed block.
+The maximum of the sum of `GasWanted` that will be allowed in a proposed block.
 This is *not* enforced by Tendermint consensus.
 It is left to the app to enforce (ie. if txs are included past the
 limit, they should return non-zero codes). It is used by Tendermint to limit the
@@ -327,15 +327,6 @@ txs included in a proposed block.
 
 Must have `MaxGas >= -1`.
 If `MaxGas == -1`, no limit is enforced.
-
-### BlockParams.TimeIotaMs
-
-The minimum time between consecutive blocks (in milliseconds).
-This is enforced by Tendermint consensus.
-
-Must have `TimeIotaMs > 0` to ensure time monotonicity.
-
-> *Note: This is not exposed to the application*
 
 ### EvidenceParams.MaxAgeDuration
 
@@ -366,7 +357,7 @@ This is the maximum number of evidence that can be committed to a single block.
 The product of this and the `MaxEvidenceBytes` must not exceed the size of
 a block minus it's overhead ( ~ `MaxBytes`).
 
-The amount must be a positive number.
+Must have `MaxNum > 0`.
 
 ### Updates
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -447,6 +447,8 @@ When verifying the full proof, the root hash for one ProofOp is the value being
 verified for the next ProofOp in the list. The root hash of the final ProofOp in
 the list should match the `AppHash` being verified against.
 
+-- It looks like have custom encoders for the merkle proof encoder decoders. Are these documented?
+
 ### Peer Filtering
 
 When Tendermint connects to a peer, it sends two queries to the ABCI application
@@ -470,13 +472,16 @@ Tendermint only uses `/p2p`, for filtering peers. For more advanced use, see the
 implementation of
 [Query in the Cosmos-SDK](https://github.com/cosmos/cosmos-sdk/blob/v0.23.1/baseapp/baseapp.go#L333).
 
+-- how does cosmos-sdk do this if tendermint only sends/receives p2p?
+
+
 ## Crash Recovery
 
 On startup, Tendermint calls the `Info` method on the Info Connection to get the latest
 committed state of the app. The app MUST return information consistent with the
 last block it succesfully completed Commit for.
 
-If the app succesfully committed block H but not H+1, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
+If the app succesfully committed block H, then `last_block_height = H` and `last_block_app_hash = <hash returned by Commit for block H>`. If the app
 failed during the Commit of block H, then `last_block_height = H-1` and
 `last_block_app_hash = <hash returned by Commit for block H-1, which is the hash in the header of block H>`.
 
@@ -489,10 +494,11 @@ stateBlockHeight = height of the last block for which Tendermint completed all
     block processing and saved all ABCI results to disk
 appBlockHeight = height of the last block for which ABCI app succesfully
     completed Commit
+
 ```
 
 Note we always have `storeBlockHeight >= stateBlockHeight` and `storeBlockHeight >= appBlockHeight`
-Note also we never call Commit on an ABCI app twice for the same height.
+Note also Tendermint never calls Commit on an ABCI app twice for the same height.
 
 The procedure is as follows.
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -116,14 +116,8 @@ care about CheckTx; it can propose a block full of invalid transactions if it wa
 To prevent old transactions from being replayed, CheckTx must implement
 replay protection.
 
-Tendermint provides the first defense layer by keeping a lightweight
-in-memory cache of recent transactions in the mempool. If Tendermint is just 
-started or the cache is full, old transactions may be sent to the application. So
+It is possible for old transactions to be sent to the application. So
 it is important CheckTx implements some logic to handle them.
-
-If there are cases in your application where a transaction may become invalid in some
-future state, you probably want to disable Tendermint's
-cache.
 
 ### Query Connection
 

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -231,7 +231,7 @@ the Tendermint protocol.
 If DeliverTx returns `Code != 0`, the transaction will be considered invalid,
 though it is still included in the block.
 
-DeliverTx also returns a [Code, Data, and Log](../proto/abci/types.proto#L189-L191).
+DeliverTx also returns a [Code, Data, and Log](../../proto/abci/types.proto#L189-L191).
 
 `Data` contains the result of the CheckTx transaction execution, if any. It is
 semantically meaningless to Tendermint.

--- a/spec/abci/apps.md
+++ b/spec/abci/apps.md
@@ -99,35 +99,29 @@ ensuring that all existing CheckTx are responded to and no new ones can
 begin.
 
 After `Commit`, CheckTx is run again on all transactions that remain in the
-node's local mempool after filtering those included in the block. To prevent the
-mempool from rechecking all transactions every time a block is committed, set
-the configuration option `mempool.recheck=false`. As of Tendermint v0.32.1,
-an additional `Type` parameter is made available to the CheckTx function that
+node's local mempool after filtering those included in the block.
+An additional `Type` parameter is made available to the CheckTx function that
 indicates whether an incoming transaction is new (`CheckTxType_New`), or a
 recheck (`CheckTxType_Recheck`).
 
-Finally, after re-checking transactions in the mempool, Tendermint will unlock 
+Finally, after re-checking transactions in the mempool, Tendermint will unlock
 the mempool connection. New transactions are once again able to be processed through CheckTx.
 
-Note that CheckTx is just a weak filter to keep invalid transactions out of the block chain. 
+Note that CheckTx is just a weak filter to keep invalid transactions out of the block chain.
 CheckTx doesn't have to check everything that affects transaction validity; the
-expensive things can be skipped.  It's weak because a Byzantine node doesn't 
+expensive things can be skipped.  It's weak because a Byzantine node doesn't
 care about CheckTx; it can propose a block full of invalid transactions if it wants.
-
--- what other line of defense do we have against invalid TX? TM itself i'm assuming? --
 
 #### Replay Protection
 
 To prevent old transactions from being replayed, CheckTx must implement
 replay protection.
 
--- is this implementation specific or should it be included in the spec? -- 
 Tendermint provides the first defense layer by keeping a lightweight
 in-memory cache of recent transactions in the mempool. If Tendermint is just 
 started or the cache is full, old transactions may be sent to the application. So
 it is important CheckTx implements some logic to handle them.
 
--- this feels go specific
 If there are cases in your application where a transaction may become invalid in some
 future state, you probably want to disable Tendermint's
 cache.
@@ -371,16 +365,16 @@ value to be updated to 0.
 #### InitChain
 
 ResponseInitChain includes a ConsensusParams.
-If its nil, Tendermint will use the params loaded in the genesis
-file. If it's not nil, Tendermint will use it.
+If ConsensusParams is nil, Tendermint will use the params loaded in the genesis
+file. If ConsensusParams is not nil, Tendermint will use it.
 This way the application can determine the initial consensus params for the
 blockchain.
 
 #### EndBlock
 
 ResponseEndBlock includes a ConsensusParams.
-If its nil, Tendermint will do nothing.
-If it's not nil, Tendermint will use it.
+If ConsensusParams nil, Tendermint will do nothing.
+If ConsensusParam is not nil, Tendermint will use it.
 This way the application can update the consensus params over time.
 
 Note the updates returned in block `H` will take effect right away for block
@@ -422,8 +416,7 @@ ABCI applications can take advantage of more efficient light-client proofs for
 their state as follows:
 
 - return the Merkle root of the deterministic application state in
-`ResponseCommit.Data`.
-- it will be included as the `AppHash` in the next block.
+`ResponseCommit.Data`. This Merkle root will be included as the `AppHash` in the next block.
 - return efficient Merkle proofs about that application state in `ResponseQuery.Proof`
   that can be verified using the `AppHash` of the corresponding block.
 


### PR DESCRIPTION
This pull requests offers several fixups to the apps.md document. The changes are primarily in areas that I found somewhat unclear or where language needed to be modified to reflect the more current state of the system. An example of this is the recent rename of fast sync to 'block sync'.