### PR TITLE
pex: update pex messages

### DIFF
--- a/proto/tendermint/p2p/pex.proto
+++ b/proto/tendermint/p2p/pex.proto
@@ -6,9 +6,7 @@ option go_package = "github.com/tendermint/tendermint/proto/tendermint/p2p";
 import "gogoproto/gogo.proto";
 
 message PexAddress {
-  string id   = 1 [(gogoproto.customname) = "ID"];
-  string ip   = 2 [(gogoproto.customname) = "IP"];
-  uint32 port = 3;
+  string url = 1 [(gogoproto.customname) = "URL"];
 }
 
 message PexRequest {}
@@ -17,21 +15,9 @@ message PexResponse {
   repeated PexAddress addresses = 1 [(gogoproto.nullable) = false];
 }
 
-message PexAddressV2 {
-  string url = 1 [(gogoproto.customname) = "URL"];
-}
-
-message PexRequestV2 {}
-
-message PexResponseV2 {
-  repeated PexAddressV2 addresses = 1 [(gogoproto.nullable) = false];
-}
-
 message PexMessage {
   oneof sum {
     PexRequest    pex_request     = 1;
     PexResponse   pex_response    = 2;
-    PexRequestV2  pex_request_v2  = 3;
-    PexResponseV2 pex_response_v2 = 4;
   }
 }

--- a/spec/p2p/messages/pex.md
+++ b/spec/p2p/messages/pex.md
@@ -14,9 +14,6 @@ Pex has one channel. The channel identifier is listed below.
 
 ## Message Types
 
-The current PEX service has two versions. The first uses IP/port pair but since the p2p stack is moving towards a transport agnostic approach, 
-node endpoints require a `Protocol` and `Path` hence the V2 version uses a [url](https://golang.org/pkg/net/url/#URL) instead.
-
 ### PexRequest
 
 PexRequest is an empty message requesting a list of peers.
@@ -37,31 +34,6 @@ PexAddress provides needed information for a node to dial a peer.
 
 | Name | Type   | Description      | Field Number |
 |------|--------|------------------|--------------|
-| id   | string | NodeID of a peer | 1            |
-| ip   | string | The IP of a node | 2            |
-| port | port   | Port of a peer   | 3            |
-
-
-### PexRequestV2
-
-PexRequest is an empty message requesting a list of peers.
-
-> EmptyRequest
-
-### PexResponseV2
-
-PexResponse is an list of net addresses provided to a peer to dial.
-
-| Name  | Type                               | Description                              | Field Number |
-|-------|------------------------------------|------------------------------------------|--------------|
-| addresses | repeated [PexAddressV2](#PexAddressV2) | List of peer addresses available to dial | 1            |
-
-### PexAddressV2
-
-PexAddress provides needed information for a node to dial a peer.
-
-| Name | Type   | Description      | Field Number |
-|------|--------|------------------|--------------|
 | url   | string | See [golang url](https://golang.org/pkg/net/url/#URL) | 1            |
 
 ### Message
@@ -72,5 +44,3 @@ Message is a [`oneof` protobuf type](https://developers.google.com/protocol-buff
 |--------------|---------------------------|------------------------------------------------------|--------------|
 | pex_request  | [PexRequest](#PexRequest) | Empty request asking for a list of addresses to dial | 1            |
 | pex_response | [PexResponse](#PexResponse)  | List of addresses to dial                            | 2            |
-| pex_request_v2 | [PexRequestV2](#PexRequestV2) | Empty request asking for a list of addresses to dial | 3         |
-| pex_response_v2 | [PexRespinseV2](#PexResponseV2) | List of addresses to dial | 4 |


### PR DESCRIPTION
This PR proposes a p2p breaking change, cleaning up the PEX messages by removing the v1 version for the legacy p2p system and having a single pex receive and response message type.