### PR TITLE
Update build image workflow.

### DIFF
--- a/.github/workflows/proto-dockerfile.yml
+++ b/.github/workflows/proto-dockerfile.yml
@@ -5,9 +5,8 @@
 # should merge the updates first and wait for this workflow to complete,
 # so that the changes will be available for the dependent workflows.
 #
-# TODO(#7272): Update the target location of the builder image.
 
-name: Build & Push TM Proto Builder
+name: Build & Push Proto Builder Image
 on:
   pull_request:
     paths:
@@ -21,15 +20,19 @@ on:
     # run this job once a month to recieve any go or buf updates
     - cron: "* * 1 * *"
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tendermint/docker-build-proto
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Prepare
+      - name: Check out and assign tags
         id: prep
         run: |
-          DOCKER_IMAGE=tendermintdev/docker-build-proto
+          DOCKER_IMAGE="${REGISTRY}/${IMAGE_NAME}"
           VERSION=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -42,16 +45,17 @@ jobs:
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           echo ::set-output name=tags::${TAGS}
 
-      - name: Set up Docker Buildx
+      - name: Set up docker buildx
         uses: docker/setup-buildx-action@v1.6.0
 
-      - name: Login to DockerHub
+      - name: Log in to the container registry
         uses: docker/login-action@v1.10.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
+      - name: Build and publish image
         uses: docker/build-push-action@v2.7.0
         with:
           context: ./proto

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,19 +1,14 @@
 # This Dockerfile defines an image containing tools for linting, formatting,
 # and compiling the Tendermint protos.
-
-FROM bufbuild/buf:latest as buf
-
 FROM golang:1.17-alpine
 
 # Install a commonly used set of programs for use with our protos.
 # clang-extra-tools is included here because it provides clang-format,
 # used to format the .proto files.
-RUN apk add --update --no-cache build-base clang-extra-tools curl git && \
-  apk add --update --no-cache build-base clang-extra-tools curl git go && \
-  rm -rf /var/cache/apk/*
+RUN apk add --no-cache build-base clang-extra-tools curl git
 
 ENV GOLANG_PROTOBUF_VERSION=1.3.1 \
-  GOGO_PROTOBUF_VERSION=1.3.2
+    GOGO_PROTOBUF_VERSION=1.3.2
 
 # Retrieve the go protoc programs and copy them into the PATH
 RUN go install github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION} && \
@@ -22,4 +17,4 @@ RUN go install github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSI
   mv "$(go env GOPATH)"/bin/* /usr/local/bin/
 
 # Copy the 'buf' program out of the buildbuf/buf container.
-COPY --from=buf /usr/local/bin/* /usr/local/bin/
+COPY --from=bufbuild/buf:latest /usr/local/bin/* /usr/local/bin/


### PR DESCRIPTION
Updates https://github.com/tendermint/tendermint/issues/7272.

The main effect of this change is to push the builder image to ghcr.io instead of dockerhub. For this change to take effect we will also need to update the Makefile, but we cannot do that until the image has been pushed since the CI workflow uses the existing tag.