### PR TITLE
acbi: fix readme link to protocol buffers

### DIFF
--- a/spec/abci/README.md
+++ b/spec/abci/README.md
@@ -14,7 +14,7 @@ _methods_, each with a corresponding `Request` and `Response`message type.
 To perform state-machine replication, Tendermint calls the ABCI methods on the 
 ABCI application by sending the `Request*` messages and receiving the `Response*` messages in return.
 
-All ABCI messages and methods are defined in [protocol buffers](https://github.com/tendermint/spec/blob/master/proto/abci/types.proto). 
+All ABCI messages and methods are defined in [protocol buffers](https://github.com/tendermint/spec/blob/master/proto/tendermint/abci/types.proto).
 This allows Tendermint to run with applications written in many programming languages.
 
 This specification is split as follows:


### PR DESCRIPTION
Just fixing a broken link