### PR TITLE
proto: rename timing params to synchrony params

### DIFF
--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -13,7 +13,7 @@ message ConsensusParams {
   EvidenceParams  evidence  = 2;
   ValidatorParams validator = 3;
   VersionParams   version   = 4;
-  SynchronyParams timing    = 5;
+  SynchronyParams synchrony = 5;
 }
 
 // BlockParams contains limits on the block size.

--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -13,7 +13,7 @@ message ConsensusParams {
   EvidenceParams  evidence  = 2;
   ValidatorParams validator = 3;
   VersionParams   version   = 4;
-  TimingParams    timing    = 5;
+  SynchronyParams timing    = 5;
 }
 
 // BlockParams contains limits on the block size.
@@ -67,9 +67,9 @@ message HashedParams {
   int64 block_max_gas   = 2;
 }
 
-message TimingParams {
+message SynchronyParams {
   google.protobuf.Duration message_delay = 1
       [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-  google.protobuf.Duration  precision = 2
+  google.protobuf.Duration precision = 2
       [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 }


### PR DESCRIPTION
This pull request renames the PBTS parameters from `TimingParams` to `SynchronyParams`. This name more specifically reflects what the parameters are for. Additionally, another set of consensus parameters are planned to be added called `TimeoutParams` as part of the work for [ADR-74](https://github.com/tendermint/tendermint/pull/7503). The similarity of these names will definitely cause confusion so changing this name seems like a good fix.