### PR TITLE
Adapt abci protobuf files to ABCI++ spec (and vice versa)

### DIFF
--- a/.github/workflows/proto-dockerfile.yml
+++ b/.github/workflows/proto-dockerfile.yml
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish image
-        uses: docker/build-push-action@v2.8.0
+        uses: docker/build-push-action@v2.9.0
         with:
           context: ./proto
           file: ./proto/Dockerfile

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -37,10 +37,10 @@ message Request {
     RequestApplySnapshotChunk  apply_snapshot_chunk  = 14;
     RequestPrepareProposal     prepare_proposal      = 15;
     RequestProcessProposal     process_proposal      = 16;
-    RequestExtendVote          extend_vote           = 17;
-    RequestVerifyVoteExtension verify_vote_extension = 18;
     RequestFinalizeBlock       finalize_block        = 19;
   }
+  reserved 17; // Placeholder for RequestExtendVote in v0.37
+  reserved 18; // Placeholder for RequestVerifyVoteExtension in v0.37
 }
 
 message RequestEcho {
@@ -142,21 +142,6 @@ message RequestProcessProposal {
   repeated Evidence       byzantine_validators = 5 [(gogoproto.nullable) = false];
 }
 
-// Extends a vote with application-side injection
-message RequestExtendVote {
-  bytes hash   = 1;
-  int64 height = 2;
-}
-
-// Verify the vote extension
-message RequestVerifyVoteExtension {
-  bytes app_signed        = 1;
-  bytes tendermint_signed = 2;
-  bytes hash              = 3;
-  bytes validator_address = 4;
-  int64 height            = 5;
-}
-
 message RequestFinalizeBlock {
   bytes                   hash                 = 1;
   tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
@@ -187,10 +172,10 @@ message Response {
     ResponseApplySnapshotChunk  apply_snapshot_chunk  = 15;
     ResponsePrepareProposal     prepare_proposal      = 16;
     ResponseProcessProposal     process_proposal      = 17;
-    ResponseExtendVote          extend_vote           = 18;
-    ResponseVerifyVoteExtension verify_vote_extension = 19;
     ResponseFinalizeBlock       finalize_block        = 20;
   }
+  reserved 18; // Placeholder for ResponseExtendVote in v0.37
+  reserved 19; // Placeholder for ResponseVerifyVoteExtension in v0.37
 }
 
 // nondeterministic
@@ -323,7 +308,7 @@ message ResponsePrepareProposal {
   repeated ExecTxResult            tx_results              = 4;
   repeated ValidatorUpdate         validator_updates       = 5;
   tendermint.types.ConsensusParams consensus_param_updates = 6;
-  repeated bytes                   app_signed_updates      = 7;
+  reserved 7; // Placeholder for app_signed_updates in v0.37
 }
 
 message ResponseProcessProposal {
@@ -332,15 +317,6 @@ message ResponseProcessProposal {
   repeated ExecTxResult            tx_results              = 3;
   repeated ValidatorUpdate         validator_updates       = 4;
   tendermint.types.ConsensusParams consensus_param_updates = 5;
-}
-
-message ResponseExtendVote {
-  bytes app_signed        = 1;
-  bytes tendermint_signed = 2;
-}
-
-message ResponseVerifyVoteExtension {
-  bool accept = 1;
 }
 
 message ResponseFinalizeBlock {
@@ -436,8 +412,8 @@ message ValidatorUpdate {
 message VoteInfo {
   Validator validator                   = 1 [(gogoproto.nullable) = false];
   bool      signed_last_block           = 2;
-  bytes     tendermint_signed_extension = 3;
-  bytes     app_signed_extension        = 4;
+  reserved 3; // Placeholder for tendermint_signed_extension in v0.37
+  reserved 4; // Placeholder for app_signed_extension in v0.37
 }
 
 enum EvidenceType {
@@ -488,7 +464,5 @@ service ABCIApplication {
   rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
   rpc PrepareProposal(RequestPrepareProposal) returns (ResponsePrepareProposal);
   rpc ProcessProposal(RequestProcessProposal) returns (ResponseProcessProposal);
-  rpc ExtendVote(RequestExtendVote) returns (ResponseExtendVote);
-  rpc VerifyVoteExtension(RequestVerifyVoteExtension) returns (ResponseVerifyVoteExtension);
   rpc FinalizeBlock(RequestFinalizeBlock) returns (ResponseFinalizeBlock);
 }

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -21,20 +21,24 @@ import "gogoproto/gogo.proto";
 
 message Request {
   oneof value {
-    RequestEcho               echo                 = 1;
-    RequestFlush              flush                = 2;
-    RequestInfo               info                 = 3;
-    RequestInitChain          init_chain           = 4;
-    RequestQuery              query                = 5;
-    RequestBeginBlock         begin_block          = 6;
-    RequestCheckTx            check_tx             = 7;
-    RequestDeliverTx          deliver_tx           = 8;
-    RequestEndBlock           end_block            = 9;
-    RequestCommit             commit               = 10;
-    RequestListSnapshots      list_snapshots       = 11;
-    RequestOfferSnapshot      offer_snapshot       = 12;
-    RequestLoadSnapshotChunk  load_snapshot_chunk  = 13;
-    RequestApplySnapshotChunk apply_snapshot_chunk = 14;
+    RequestEcho                echo                  = 1;
+    RequestFlush               flush                 = 2;
+    RequestInfo                info                  = 3;
+    RequestInitChain           init_chain            = 4;
+    RequestQuery               query                 = 5;
+    RequestBeginBlock          begin_block           = 6 [deprecated = true];
+    RequestCheckTx             check_tx              = 7;
+    RequestDeliverTx           deliver_tx            = 8 [deprecated = true];
+    RequestEndBlock            end_block             = 9 [deprecated = true];
+    RequestCommit              commit                = 10;
+    RequestListSnapshots       list_snapshots        = 11;
+    RequestOfferSnapshot       offer_snapshot        = 12;
+    RequestLoadSnapshotChunk   load_snapshot_chunk   = 13;
+    RequestApplySnapshotChunk  apply_snapshot_chunk  = 14;
+    RequestPrepareProposal     prepare_proposal      = 15;
+    RequestExtendVote          extend_vote           = 16;
+    RequestVerifyVoteExtension verify_vote_extension = 17;
+    RequestFinalizeBlock       finalize_block        = 18;
   }
 }
 
@@ -117,26 +121,57 @@ message RequestApplySnapshotChunk {
   string sender = 3;
 }
 
+// Extends a vote with application-side injection
+message RequestExtendVote {
+  types.Vote vote = 1;
+}
+
+// Verify the vote extension
+message RequestVerifyVoteExtension {
+  types.Vote vote = 1;
+}
+
+message RequestPrepareProposal {
+  // block_data is an array of transactions that will be included in a block,
+  // sent to the app for possible modifications.
+  // applications can not exceed the size of the data passed to it.
+  repeated bytes block_data = 1;
+  // If an application decides to populate block_data with extra information, they can not exceed this value.
+  int64 block_data_size = 2;
+}
+
+message RequestFinalizeBlock {
+  repeated bytes          txs                  = 1;
+  bytes                   hash                 = 2;
+  tendermint.types.Header header               = 3 [(gogoproto.nullable) = false];
+  LastCommitInfo          last_commit_info     = 4 [(gogoproto.nullable) = false];
+  repeated Evidence       byzantine_validators = 5 [(gogoproto.nullable) = false];
+}
+
 //----------------------------------------
 // Response types
 
 message Response {
   oneof value {
-    ResponseException          exception            = 1;
-    ResponseEcho               echo                 = 2;
-    ResponseFlush              flush                = 3;
-    ResponseInfo               info                 = 4;
-    ResponseInitChain          init_chain           = 5;
-    ResponseQuery              query                = 6;
-    ResponseBeginBlock         begin_block          = 7;
-    ResponseCheckTx            check_tx             = 8;
-    ResponseDeliverTx          deliver_tx           = 9;
-    ResponseEndBlock           end_block            = 10;
-    ResponseCommit             commit               = 11;
-    ResponseListSnapshots      list_snapshots       = 12;
-    ResponseOfferSnapshot      offer_snapshot       = 13;
-    ResponseLoadSnapshotChunk  load_snapshot_chunk  = 14;
-    ResponseApplySnapshotChunk apply_snapshot_chunk = 15;
+    ResponseException           exception             = 1;
+    ResponseEcho                echo                  = 2;
+    ResponseFlush               flush                 = 3;
+    ResponseInfo                info                  = 4;
+    ResponseInitChain           init_chain            = 5;
+    ResponseQuery               query                 = 6;
+    ResponseBeginBlock          begin_block           = 7 [deprecated = true];
+    ResponseCheckTx             check_tx              = 8;
+    ResponseDeliverTx           deliver_tx            = 9 [deprecated = true];
+    ResponseEndBlock            end_block             = 10 [deprecated = true];
+    ResponseCommit              commit                = 11;
+    ResponseListSnapshots       list_snapshots        = 12;
+    ResponseOfferSnapshot       offer_snapshot        = 13;
+    ResponseLoadSnapshotChunk   load_snapshot_chunk   = 14;
+    ResponseApplySnapshotChunk  apply_snapshot_chunk  = 15;
+    ResponsePrepareProposal     prepare_proposal      = 16;
+    ResponseExtendVote          extend_vote           = 17;
+    ResponseVerifyVoteExtension verify_vote_extension = 18;
+    ResponseFinalizeBlock       finalize_block        = 19;
   }
 }
 
@@ -198,6 +233,7 @@ message ResponseCheckTx {
   int64          priority   = 10;
 
   // mempool_error is set by Tendermint.
+
   // ABCI applications creating a ResponseCheckTX should not set mempool_error.
   string mempool_error = 11;
 }
@@ -260,6 +296,32 @@ message ResponseApplySnapshotChunk {
     RETRY_SNAPSHOT  = 4;  // Retry snapshot (combine with refetch and reject)
     REJECT_SNAPSHOT = 5;  // Reject this snapshot, try others
   }
+}
+
+message ResponseExtendVote {
+  tendermint.types.VoteExtension vote_extension = 1;
+}
+
+message ResponseVerifyVoteExtension {
+  Result result = 1;
+
+  enum Result {
+    UNKNOWN = 0;  // Unknown result, treat as ACCEPT by default
+    ACCEPT  = 1;  // Vote extension verified, include the vote
+    SLASH   = 2;  // Vote extension verification aborted, continue but slash validator
+    REJECT  = 3;  // Vote extension invalidated
+  }
+}
+
+message ResponsePrepareProposal {
+  repeated bytes block_data = 1;
+}
+
+message ResponseFinalizeBlock {
+  repeated ResponseDeliverTx       txs                     = 1;
+  repeated ValidatorUpdate         validator_updates       = 2 [(gogoproto.nullable) = false];
+  tendermint.types.ConsensusParams consensus_param_updates = 3;
+  repeated Event                   events                  = 4 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
 }
 
 //----------------------------------------
@@ -355,15 +417,15 @@ service ABCIApplication {
   rpc Echo(RequestEcho) returns (ResponseEcho);
   rpc Flush(RequestFlush) returns (ResponseFlush);
   rpc Info(RequestInfo) returns (ResponseInfo);
-  rpc DeliverTx(RequestDeliverTx) returns (ResponseDeliverTx);
   rpc CheckTx(RequestCheckTx) returns (ResponseCheckTx);
   rpc Query(RequestQuery) returns (ResponseQuery);
   rpc Commit(RequestCommit) returns (ResponseCommit);
   rpc InitChain(RequestInitChain) returns (ResponseInitChain);
-  rpc BeginBlock(RequestBeginBlock) returns (ResponseBeginBlock);
-  rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
   rpc ListSnapshots(RequestListSnapshots) returns (ResponseListSnapshots);
   rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
   rpc LoadSnapshotChunk(RequestLoadSnapshotChunk) returns (ResponseLoadSnapshotChunk);
   rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
+  rpc ExtendVote(RequestExtendVote) returns (ResponseExtendVote);
+  rpc VerifyVoteExtension(RequestVerifyVoteExtension) returns (ResponseVerifyVoteExtension);
+  rpc PrepareProposal(RequestPrepareProposal) returns (ResponsePrepareProposal);
 }

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -36,9 +36,10 @@ message Request {
     RequestLoadSnapshotChunk   load_snapshot_chunk   = 13;
     RequestApplySnapshotChunk  apply_snapshot_chunk  = 14;
     RequestPrepareProposal     prepare_proposal      = 15;
-    RequestExtendVote          extend_vote           = 16;
-    RequestVerifyVoteExtension verify_vote_extension = 17;
-    RequestFinalizeBlock       finalize_block        = 18;
+    RequestProcessProposal     process_proposal      = 16;
+    RequestExtendVote          extend_vote           = 17;
+    RequestVerifyVoteExtension verify_vote_extension = 18;
+    RequestFinalizeBlock       finalize_block        = 19;
   }
 }
 
@@ -121,29 +122,45 @@ message RequestApplySnapshotChunk {
   string sender = 3;
 }
 
+message RequestPrepareProposal {
+  bytes                   hash                 = 1;
+  tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
+  // txs is an array of transactions that will be included in a block,
+  // sent to the app for possible modifications.
+  repeated bytes          txs                  = 3;
+  LastCommitInfo          last_commit_info     = 4 [(gogoproto.nullable) = false];
+  repeated Evidence       byzantine_validators = 5 [(gogoproto.nullable) = false];
+  // the modified transactions cannot exceed this size.
+  int64                   max_tx_bytes         = 6;
+}
+
+message RequestProcessProposal {
+  bytes                   hash                 = 1;
+  tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
+  repeated bytes          txs                  = 3;
+  LastCommitInfo          last_commit_info     = 4 [(gogoproto.nullable) = false];
+  repeated Evidence       byzantine_validators = 5 [(gogoproto.nullable) = false];
+}
+
 // Extends a vote with application-side injection
 message RequestExtendVote {
-  types.Vote vote = 1;
+  bytes hash   = 1;
+  int64 height = 2;
 }
 
 // Verify the vote extension
 message RequestVerifyVoteExtension {
-  types.Vote vote = 1;
-}
-
-message RequestPrepareProposal {
-  // block_data is an array of transactions that will be included in a block,
-  // sent to the app for possible modifications.
-  // applications can not exceed the size of the data passed to it.
-  repeated bytes block_data = 1;
-  // If an application decides to populate block_data with extra information, they can not exceed this value.
-  int64 block_data_size = 2;
+  bytes app_signed        = 1;
+  bytes tendermint_signed = 2;
+  bytes hash              = 3;
+  bytes validator_address = 4;
+  int64 height            = 5;
 }
 
 message RequestFinalizeBlock {
-  repeated bytes          txs                  = 1;
-  bytes                   hash                 = 2;
-  tendermint.types.Header header               = 3 [(gogoproto.nullable) = false];
+  bytes                   hash                 = 1;
+  tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
+  repeated bytes          txs                  = 3;
   LastCommitInfo          last_commit_info     = 4 [(gogoproto.nullable) = false];
   repeated Evidence       byzantine_validators = 5 [(gogoproto.nullable) = false];
 }
@@ -169,9 +186,10 @@ message Response {
     ResponseLoadSnapshotChunk   load_snapshot_chunk   = 14;
     ResponseApplySnapshotChunk  apply_snapshot_chunk  = 15;
     ResponsePrepareProposal     prepare_proposal      = 16;
-    ResponseExtendVote          extend_vote           = 17;
-    ResponseVerifyVoteExtension verify_vote_extension = 18;
-    ResponseFinalizeBlock       finalize_block        = 19;
+    ResponseProcessProposal     process_proposal      = 17;
+    ResponseExtendVote          extend_vote           = 18;
+    ResponseVerifyVoteExtension verify_vote_extension = 19;
+    ResponseFinalizeBlock       finalize_block        = 20;
   }
 }
 
@@ -225,8 +243,8 @@ message ResponseCheckTx {
   bytes          data       = 2;
   string         log        = 3;  // nondeterministic
   string         info       = 4;  // nondeterministic
-  int64          gas_wanted = 5 [json_name = "gas_wanted"];
-  int64          gas_used   = 6 [json_name = "gas_used"];
+  int64          gas_wanted = 5;
+  int64          gas_used   = 6;
   repeated Event events     = 7 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
   string         codespace  = 8;
   string         sender     = 9;
@@ -298,30 +316,41 @@ message ResponseApplySnapshotChunk {
   }
 }
 
+message ResponsePrepareProposal {
+  bool                             modified_tx             = 1;
+  repeated TxRecord                tx_records              = 2;
+  bytes                            app_hash                = 3;
+  repeated ExecTxResult            tx_results              = 4;
+  repeated ValidatorUpdate         validator_updates       = 5;
+  tendermint.types.ConsensusParams consensus_param_updates = 6;
+  repeated bytes                   app_signed_updates      = 7;
+}
+
+message ResponseProcessProposal {
+  bool                             accept                  = 1;
+  bytes                            app_hash                = 2;
+  repeated ExecTxResult            tx_results              = 3;
+  repeated ValidatorUpdate         validator_updates       = 4;
+  tendermint.types.ConsensusParams consensus_param_updates = 5;
+}
+
 message ResponseExtendVote {
-  tendermint.types.VoteExtension vote_extension = 1;
+  bytes app_signed        = 1;
+  bytes tendermint_signed = 2;
 }
 
 message ResponseVerifyVoteExtension {
-  Result result = 1;
-
-  enum Result {
-    UNKNOWN = 0;  // Unknown result, treat as ACCEPT by default
-    ACCEPT  = 1;  // Vote extension verified, include the vote
-    SLASH   = 2;  // Vote extension verification aborted, continue but slash validator
-    REJECT  = 3;  // Vote extension invalidated
-  }
-}
-
-message ResponsePrepareProposal {
-  repeated bytes block_data = 1;
+  bool accept = 1;
 }
 
 message ResponseFinalizeBlock {
-  repeated ResponseDeliverTx       txs                     = 1;
-  repeated ValidatorUpdate         validator_updates       = 2 [(gogoproto.nullable) = false];
-  tendermint.types.ConsensusParams consensus_param_updates = 3;
-  repeated Event                   events                  = 4 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+  repeated Event                   block_events            = 1
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+  repeated ExecTxResult            tx_results              = 2;
+  repeated ValidatorUpdate         validator_updates       = 3;
+  tendermint.types.ConsensusParams consensus_param_updates = 4;
+  bytes                            app_hash                = 5;
+  int64                            retain_height           = 6;
 }
 
 //----------------------------------------
@@ -347,6 +376,21 @@ message EventAttribute {
   bool   index = 3;  // nondeterministic
 }
 
+// ExecTxResult contains results of executing one individual transaction.
+//
+// * Its structure is equivalent to #ResponseDeliverTx which will be deprecated/deleted
+message ExecTxResult {
+  uint32         code       = 1;
+  bytes          data       = 2;
+  string         log        = 3;  // nondeterministic
+  string         info       = 4;  // nondeterministic
+  int64          gas_wanted = 5;
+  int64          gas_used   = 6;
+  repeated Event tx_events  = 7
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];  // nondeterministic
+  string          codespace = 8;
+}
+
 // TxResult contains results of executing the transaction.
 //
 // One usage is indexing transaction results.
@@ -355,6 +399,21 @@ message TxResult {
   uint32            index  = 2;
   bytes             tx     = 3;
   ResponseDeliverTx result = 4 [(gogoproto.nullable) = false];
+}
+
+message TxRecord {
+  TxAction action           = 1;
+  bytes tx                  = 2;
+  repeated bytes new_hashes = 3;
+
+  // TxAction contains App-provided information on what to do with a transaction that is part of a raw proposal
+  enum TxAction {
+    UNKNOWN    = 0;  // Unknown action
+    UNMODIFIED = 1;  // The Application did not modify this transaction. Ignore new_hashes field
+    ADDED      = 2;  // The Application added this transaction. Ignore new_hashes field
+    REMOVED    = 3;  // The Application wants this transaction removed from the proposal and the mempool.
+                     // Use #new_hashes field if the transaction was modified
+  }
 }
 
 //----------------------------------------
@@ -375,8 +434,10 @@ message ValidatorUpdate {
 
 // VoteInfo
 message VoteInfo {
-  Validator validator         = 1 [(gogoproto.nullable) = false];
-  bool      signed_last_block = 2;
+  Validator validator                   = 1 [(gogoproto.nullable) = false];
+  bool      signed_last_block           = 2;
+  bytes     tendermint_signed_extension = 3;
+  bytes     app_signed_extension        = 4;
 }
 
 enum EvidenceType {
@@ -425,7 +486,9 @@ service ABCIApplication {
   rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
   rpc LoadSnapshotChunk(RequestLoadSnapshotChunk) returns (ResponseLoadSnapshotChunk);
   rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
+  rpc PrepareProposal(RequestPrepareProposal) returns (ResponsePrepareProposal);
+  rpc ProcessProposal(RequestProcessProposal) returns (ResponseProcessProposal);
   rpc ExtendVote(RequestExtendVote) returns (ResponseExtendVote);
   rpc VerifyVoteExtension(RequestVerifyVoteExtension) returns (ResponseVerifyVoteExtension);
-  rpc PrepareProposal(RequestPrepareProposal) returns (ResponsePrepareProposal);
+  rpc FinalizeBlock(RequestFinalizeBlock) returns (ResponseFinalizeBlock);
 }

--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -14,6 +14,7 @@ message ConsensusParams {
   ValidatorParams validator = 3;
   VersionParams   version   = 4;
   SynchronyParams synchrony = 5;
+  TimeoutParams   timeout   = 6;
 }
 
 // BlockParams contains limits on the block size.
@@ -74,10 +75,53 @@ message HashedParams {
 message SynchronyParams {
   // message_delay bounds how long a proposal message may take to reach all validators on a newtork
   // and still be considered valid.
-  google.protobuf.Duration message_delay = 1
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration message_delay = 1 [(gogoproto.stdduration) = true];
   // precision bounds how skewed a proposer's clock may be from any validator
   // on the network while still producing valid proposals.
-  google.protobuf.Duration precision = 2
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration precision = 2 [(gogoproto.stdduration) = true];
+}
+
+// TimeoutParams configure the timeouts for the steps of the Tendermint consensus algorithm.
+message TimeoutParams {
+  // These fields configure the timeouts for the propose step of the Tendermint
+  // consensus algorithm: propose is the initial timeout and propose_delta
+  // determines how much the timeout grows in subsequent rounds.
+  // For the first round, this propose timeout is used and for every subsequent
+  // round, the timeout grows by propose_delta.
+  //
+  // For example:
+  // With propose = 10ms, propose_delta = 5ms, the first round's propose phase
+  // timeout would be 10ms, the second round's would be 15ms, the third 20ms and so on.
+  //
+  // If a node waiting for a proposal message does not receive one matching its
+  // current height and round before this timeout, the node will issue a
+  // nil prevote for the round and advance to the next step.
+  google.protobuf.Duration propose       = 1 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration propose_delta = 2 [(gogoproto.stdduration) = true];
+
+  // vote along with vote_delta configure the timeout for both of the prevote and
+  // precommit steps of the Tendermint consensus algorithm.
+  //
+  // These parameters influence the vote step timeouts in the the same way that
+  // the propose and propose_delta parameters do to the proposal step.
+  //
+  // The vote timeout does not begin until a quorum of votes has been received. Once
+  // a quorum of votes has been seen and this timeout elapses, Tendermint will
+  // procced to the next step of the consensus algorithm. If Tendermint receives
+  // all of the remaining votes before the end of the timeout, it will proceed
+  // to the next step immediately.
+  google.protobuf.Duration vote       = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration vote_delta = 4 [(gogoproto.stdduration) = true];
+
+  // commit configures how long Tendermint will wait after receiving a quorum of
+  // precommits before beginning consensus for the next height. This can be
+  // used to allow slow precommits to arrive for inclusion in the next height before progressing.
+  google.protobuf.Duration commit = 5 [(gogoproto.stdduration) = true];
+
+  // enable_commit_timeout_bypass configures the node to proceed immediately to
+  // the next height once the node has received all precommits for a block, forgoing
+  // the remaining commit timeout.
+  // Setting enable_commit_timeout_bypass false (the default) causes Tendermint to wait
+  // for the full commit.
+  bool enable_commit_timeout_bypass = 6;
 }

--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -13,6 +13,7 @@ message ConsensusParams {
   EvidenceParams  evidence  = 2;
   ValidatorParams validator = 3;
   VersionParams   version   = 4;
+  SynchronyParams synchrony = 5;
 }
 
 // BlockParams contains limits on the block size.
@@ -64,4 +65,19 @@ message VersionParams {
 message HashedParams {
   int64 block_max_bytes = 1;
   int64 block_max_gas   = 2;
+}
+
+// SynchronyParams configure the bounds under which a proposed block's timestamp is considered valid.
+// These parameters are part of the proposer-based timestamps algorithm. For more information,
+// see the specification of proposer-based timestamps:
+// https://github.com/tendermint/spec/tree/master/spec/consensus/proposer-based-timestamp
+message SynchronyParams {
+  // message_delay bounds how long a proposal message may take to reach all validators on a newtork
+  // and still be considered valid.
+  google.protobuf.Duration message_delay = 1
+      [(gogoproto.stdduration) = true];
+  // precision bounds how skewed a proposer's clock may be from any validator
+  // on the network while still producing valid proposals.
+  google.protobuf.Duration precision = 2
+      [(gogoproto.stdduration) = true];
 }

--- a/spec/abci++/abci++_methods_002_draft.md
+++ b/spec/abci++/abci++_methods_002_draft.md
@@ -289,9 +289,10 @@ title: Methods
     |-------------------------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------|--------------|
     | hash                    | bytes                                       | The block header's hash of the block to propose. Present for convenience (can be derived from the block header). | 1            |
     | header                  | [Header](../core/data_structures.md#header) | The header of the block to propose.                                                                              | 2            |
-    | tx                      | repeated bytes                              | Preliminary list of transactions that have been picked as part of the block to propose.                          | 3            |
-    | byzantine_validators    | repeated [Evidence](#evidence)              | List of evidence of validators that acted maliciously.                                                           | 4            |
-    | last_commit_info        | [LastCommitInfo](#lastcommitinfo)           | Info about the last commit, including the round, the validator list, and which ones signed the last block.       | 5            |
+    | txs                     | repeated bytes                              | Preliminary list of transactions that have been picked as part of the block to propose.                          | 3            |
+    | last_commit_info        | [LastCommitInfo](#lastcommitinfo)           | Info about the last commit, including the round, the validator list, and which ones signed the last block.       | 4            |
+    | byzantine_validators    | repeated [Evidence](#evidence)              | List of evidence of validators that acted maliciously.                                                           | 5            |
+    | max_tx_bytes            | int64                                       | Currently configured maximum size in bytes taken by the modified transactions.                                   | 6            |
 
 >**TODO**: Add the changes needed in LastCommitInfo for vote extensions
 
@@ -303,24 +304,31 @@ From the App's perspective, they'll probably skip ProcessProposal
     | Name                    | Type                                             | Description                                                                                 | Field Number |
     |-------------------------|--------------------------------------------------|---------------------------------------------------------------------------------------------|--------------|
     | modified_tx             | bool                                             | The Application sets it to true to denote it made changes to transactions                   | 1            |
-    | tx                      | repeated [TransactionRecord](#transactionrecord) | Possibly modified list of transactions that have been picked as part of the proposed block. | 2            |
+    | tx_records              | repeated [TxRecord](#txrecord)                   | Possibly modified list of transactions that have been picked as part of the proposed block. | 2            |
     | app_hash                | bytes                                            | The Merkle root hash of the application state.                                              | 3            |
-    | tx_result               | repeated [TxResult](#txresult)                   | List of structures containing the data resulting from executing the transactions            | 4            |
+    | tx_results              | repeated [ExecTxResult](#txresult)               | List of structures containing the data resulting from executing the transactions            | 4            |
     | validator_updates       | repeated [ValidatorUpdate](#validatorupdate)     | Changes to validator set (set voting power to 0 to remove).                                 | 5            |
     | consensus_param_updates | [ConsensusParams](#consensusparams)              | Changes to consensus-critical gas, size, and other parameters.                              | 6            |
+    | app_signed_updates      | repeated bytes                                   | Optional changes to the *app_signed* part of vote extensions.                               | 7            |
 
 * **Usage**:
     * Contains a preliminary block to be proposed, called _raw block_, which the Application can modify.
-    * The parameters and types of `RequestPrepareProposal` are the same as `RequestProcessProposal`
+    * The first five parameters of `RequestPrepareProposal` are the same as `RequestProcessProposal`
       and `RequestFinalizeBlock`.
     * The header contains the height, timestamp, and more - it exactly matches the
       Tendermint block header.
     * The Application can modify the transactions received in `RequestPrepareProposal` before sending
       them in `ResponsePrepareProposal`. In that case, `ResponsePrepareProposal.modified_tx` is set to true.
     * If `ResponsePrepareProposal.modified_tx` is false, then Tendermint will ignore the contents of
-      `ResponsePrepareProposal.tx`.
+      `ResponsePrepareProposal.tx_records`.
+    * If the Application modifies the transactions, the modified transactions MUST NOT exceed the configured maximum size,
+      contained in `RequestPrepareProposal.max_tx_bytes`.
+    * If the Application modifies the *app_signed* part of vote extensions via `ResponsePrepareProposal.app_signed_updates`,
+      the new total size of those extensions cannot exceed their initial size.
+    * The Application may choose to not modify the *app_signed* part of vote extensions by leaving parameter
+      `ResponsePrepareProposal.app_signed_updates` empty.
     * In same-block execution mode, the Application must provide values for `ResponsePrepareProposal.app_hash`,
-      `ResponsePrepareProposal.tx_result`, `ResponsePrepareProposal.validator_updates`, and
+      `ResponsePrepareProposal.tx_results`, `ResponsePrepareProposal.validator_updates`, and
       `ResponsePrepareProposal.consensus_param_updates`, as a result of fully executing the block.
         * The values for `ResponsePrepareProposal.validator_updates`, or
           `ResponsePrepareProposal.consensus_param_updates` may be empty. In this case, Tendermint will keep
@@ -337,15 +345,15 @@ From the App's perspective, they'll probably skip ProcessProposal
         * It is the responsibility of the Application to set the right value for _TimeoutPropose_ so that
           the (synchronous) execution of the block does not cause other processes to prevote `nil` because
           their propose timeout goes off.
-    * In next-block execution mode, Tendermint will ignore parameters `ResponsePrepareProposal.tx_result`,
+    * In next-block execution mode, Tendermint will ignore parameters `ResponsePrepareProposal.tx_results`,
       `ResponsePrepareProposal.validator_updates`, and `ResponsePrepareProposal.consensus_param_updates`.
     * As a result of executing the prepared proposal, the Application may produce header events or transaction events.
       The Application must keep those events until a block is decided and then pass them on to Tendermint via
       `ResponseFinalizeBlock`.
     * Likewise, in next-block execution mode, the Application must keep all responses to executing transactions
       until it can call `ResponseFinalizeBlock`.
-    * The Application can change the transaction list via `ResponsePrepareProposal.tx`.
-      See [TransactionRecord](#transactionrecord) for further information on how to use it. Some notes:
+    * The Application can change the transaction list via `ResponsePrepareProposal.tx_records`.
+      See [TxRecord](#txrecord) for further information on how to use it. Some notes:
         * To remove a transaction from the proposed block the Application _marks_ the transaction as
           "REMOVE". It does not remove it from the list. The transaction will also be removed from the mempool.
         * Removing a transaction from the list means it is too early to propose that transaction,
@@ -356,12 +364,12 @@ From the App's perspective, they'll probably skip ProcessProposal
           queries such as "what happened with this Tx?", by answering "it was modified into these ones".
         * The Application _can_ reorder the transactions in the list.
     * As a sanity check, Tendermint will check the returned parameters for validity if the Application modified them.
-      In particular, `ResponsePrepareProposal.tx` will be deemed invalid if
+      In particular, `ResponsePrepareProposal.tx_records` will be deemed invalid if
         * There is a duplicate transaction in the list.
         * The `new_hashes` field contains a dangling reference to a non-existing transaction.
-        * A new or modified transaction is marked as "UNMODIFIED" or "REMOVED".
-        * An unmodified transaction is marked as "ADDED".
-        * A transaction is marked as "UNKNOWN".
+        * A new or modified transaction is marked as "TXUNMODIFIED" or "TXREMOVED".
+        * An unmodified transaction is marked as "TXADDED".
+        * A transaction is marked as "TXUNKNOWN".
     * If Tendermint's sanity checks on the parameters of `ResponsePrepareProposal` fails, then it will drop the proposal
       and proceed to the next round (thus simulating a network loss/delay of the proposal).
         * **TODO**: [From discussion with William] Another possibility here is to panic. What do folks think we should do here?
@@ -410,23 +418,23 @@ Note that, if _p_ has a non-`nil` _validValue_, Tendermint will use it as propos
 
 * **Request**:
 
-    | Name                 | Type                                        | Description                                                                                                      | Field Number |
-    |----------------------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------|--------------|
-    | hash                 | bytes                                       | The block header's hash of the proposed block. Present for convenience (can be derived from the block header).   | 1            |
-    | header               | [Header](../core/data_structures.md#header) | The proposed block's header.                                                                                     | 2            |
-    | tx                   | repeated bytes                              | List of transactions that have been picked as part of the proposed block.                                        | 3            |
-    | byzantine_validators | repeated [Evidence](#evidence)              | List of evidence of validators that acted maliciously.                                                           | 4            |
-    | last_commit_info     | [LastCommitInfo](#lastcommitinfo)           | Info about the last commit, including the round , the validator list, and which ones signed the last block.      | 5            |
+    | Name                 | Type                                        | Description                                                                                                    | Field Number |
+    |----------------------|---------------------------------------------|----------------------------------------------------------------------------------------------------------------|--------------|
+    | hash                 | bytes                                       | The block header's hash of the proposed block. Present for convenience (can be derived from the block header). | 1            |
+    | header               | [Header](../core/data_structures.md#header) | The proposed block's header.                                                                                   | 2            |
+    | txs                  | repeated bytes                              | List of transactions that have been picked as part of the proposed block.                                      | 3            |
+    | last_commit_info     | [LastCommitInfo](#lastcommitinfo)           | Info about the last commit, including the round , the validator list, and which ones signed the last block.    | 4            |
+    | byzantine_validators | repeated [Evidence](#evidence)              | List of evidence of validators that acted maliciously.                                                         | 5            |
 
 * **Response**:
 
-    | Name                    | Type                                             | Description                                                                      | Field Number |
-    |-------------------------|--------------------------------------------------|----------------------------------------------------------------------------------|--------------|
-    | accept                  | bool                                             | If false, the received block failed verification                                 | 1            |
-    | app_hash                | bytes                                            | The Merkle root hash of the application state.                                   | 2            |
-    | tx_result               | repeated [TxResult](#txresult)                   | List of structures containing the data resulting from executing the transactions | 3            |
-    | validator_updates       | repeated [ValidatorUpdate](#validatorupdate)     | Changes to validator set (set voting power to 0 to remove).                      | 4            |
-    | consensus_param_updates | [ConsensusParams](#consensusparams)              | Changes to consensus-critical gas, size, and other parameters.                   | 5            |
+    | Name                    | Type                                             | Description                                                                       | Field Number |
+    |-------------------------|--------------------------------------------------|-----------------------------------------------------------------------------------|--------------|
+    | accept                  | bool                                             | If false, the received block failed verification.                                 | 1            |
+    | app_hash                | bytes                                            | The Merkle root hash of the application state.                                    | 2            |
+    | tx_results              | repeated [ExecTxResult](#txresult)               | List of structures containing the data resulting from executing the transactions. | 3            |
+    | validator_updates       | repeated [ValidatorUpdate](#validatorupdate)     | Changes to validator set (set voting power to 0 to remove).                       | 4            |
+    | consensus_param_updates | [ConsensusParams](#consensusparams)              | Changes to consensus-critical gas, size, and other parameters.                    | 5            |
 
 * **Usage**:
     * Contains a full proposed block.
@@ -446,13 +454,13 @@ Note that, if _p_ has a non-`nil` _validValue_, Tendermint will use it as propos
     * If `ResponseProcessProposal.accept` is _false_, Tendermint assumes the proposal received
       is not valid.
     * In same-block execution mode, the Application is required to fully execute the block and provide values
-      for parameters `ResponseProcessProposal.app_hash`, `ResponseProcessProposal.tx_result`,
+      for parameters `ResponseProcessProposal.app_hash`, `ResponseProcessProposal.tx_results`,
       `ResponseProcessProposal.validator_updates`, and `ResponseProcessProposal.consensus_param_updates`,
       so that Tendermint can then verify the hashes in the block's header are correct.
       If the hashes mismatch, Tendermint will reject the block even if `ResponseProcessProposal.accept`
       was set to _true_.
     * In next-block execution mode, the Application should *not* provide values for parameters
-      `ResponseProcessProposal.app_hash`, `ResponseProcessProposal.tx_result`,
+      `ResponseProcessProposal.app_hash`, `ResponseProcessProposal.tx_results`,
       `ResponseProcessProposal.validator_updates`, and `ResponseProcessProposal.consensus_param_updates`.
     * The implementation of `ProcessProposal` MUST be deterministic. Moreover, the value of
       `ResponseProcessProposal.accept` MUST **exclusively** depend on the parameters passed in
@@ -489,22 +497,25 @@ When a validator _p_ enters Tendermint consensus round _r_, height _h_, in which
 
 * **Request**:
 
-    | Name   | Type  | Description                                                                  | Field Number |
-    |--------|-------|------------------------------------------------------------------------------|--------------|
-    | hash   | bytes | The header hash of the proposed block that the vote extension is to refer to | 1            |
-    | height | int64 | Height of the proposed block (for sanity check).                             | 2            |
+    | Name   | Type  | Description                                                                   | Field Number |
+    |--------|-------|-------------------------------------------------------------------------------|--------------|
+    | hash   | bytes | The header hash of the proposed block that the vote extension is to refer to. | 1            |
+    | height | int64 | Height of the proposed block (for sanity check).                              | 2            |
 
 * **Response**:
 
-    | Name      | Type  | Description                                                         | Field Number |
-    |-----------|-------|---------------------------------------------------------------------|--------------|
-    | extension | bytes | Optional information that will be attached to the Precommit message | 1            |
+    | Name              | Type  | Description                                                         | Field Number |
+    |-------------------|-------|---------------------------------------------------------------------|--------------|
+    | app_signed        | bytes | Optional information signed by the Application (not by Tendermint). | 1            |
+    | tendermint_signed | bytes | Optional information signed by Tendermint.                          | 2            |
 
 * **Usage**:
+    * Both `ResponseExtendVote.app_signed` and `ResponseExtendVote.tendermint_signed` are optional information that will
+      be attached to the Precommit message.
     * `RequestExtendVote.hash` corresponds to the hash of a proposed block that was made available to the application
-      in a previous call to `ProcessProposal` for the current height.
-    * `ResponseExtendVote.extension` will always be attached to a non-`nil` Precommit message. If Tendermint is to
-      precommit `nil`, it will not call `RequestExtendVote`.
+      in a previous call to `ProcessProposal` or `PrepareProposal` for the current height.
+    * `ResponseExtendVote.app_signed` and `ResponseExtendVote.tendermint_signed` will always be attached to a non-`nil`
+      Precommit message. If Tendermint is to precommit `nil`, it will not call `RequestExtendVote`.
     * The Application logic that creates the extension can be non-deterministic.
 
 #### When does Tendermint call it?
@@ -530,12 +541,13 @@ In the cases when _p_'s Tendermint is to broadcast `precommit nil` messages (eit
 
 * **Request**:
 
-    | Name      | Type  | Description                                                                              | Field Number |
-    |-----------|-------|------------------------------------------------------------------------------------------|--------------|
-    | extension | bytes | Sender Application's vote extension to be validated                                      | 1            |
-    | hash      | bytes | The header hash of the propsed block that the vote extension refers to                   | 2            |
-    | address   | bytes | [Address](../core/data_structures.md#address) of the validator that signed the extension | 3            |
-    | height    | int64 | Height of the block  (for sanity check).                                                 | 4            |
+    | Name              | Type  | Description                                                                              | Field Number |
+    |-------------------|-------|------------------------------------------------------------------------------------------|--------------|
+    | app_signed        | bytes | Optional information signed by the Application (not by Tendermint).                      | 1            |
+    | tendermint_signed | bytes | Optional information signed by Tendermint.                                               | 2            |
+    | hash              | bytes | The header hash of the propsed block that the vote extension refers to.                  | 3            |
+    | validator_address | bytes | [Address](../core/data_structures.md#address) of the validator that signed the extension | 4            |
+    | height            | int64 | Height of the block  (for sanity check).                                                 | 5            |
 
 * **Response**:
 
@@ -580,20 +592,20 @@ from this condition, but not sure), and _p_ receives a Precommit message for rou
     |----------------------|---------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------|
     | hash                 | bytes                                       | The block header's hash. Present for convenience (can be derived from the block header).                          | 1            |
     | header               | [Header](../core/data_structures.md#header) | The block header.                                                                                                 | 2            |
-    | tx                   | repeated bytes                              | List of transactions committed as part of the block.                                                              | 3            |
-    | byzantine_validators | repeated [Evidence](#evidence)              | List of evidence of validators that acted maliciously.                                                            | 4            |
-    | last_commit_info     | [LastCommitInfo](#lastcommitinfo)           | Info about the last commit, including the round, and the list of validators and which ones signed the last block. | 5            |
+    | txs                  | repeated bytes                              | List of transactions committed as part of the block.                                                              | 3            |
+    | last_commit_info     | [LastCommitInfo](#lastcommitinfo)           | Info about the last commit, including the round, and the list of validators and which ones signed the last block. | 4            |
+    | byzantine_validators | repeated [Evidence](#evidence)              | List of evidence of validators that acted maliciously.                                                            | 5            |
 
 * **Response**:
 
     | Name                    | Type                                                        | Description                                                                      | Field Number |
     |-------------------------|-------------------------------------------------------------|----------------------------------------------------------------------------------|--------------|
     | block_events            | repeated [Event](abci++_basic_concepts_002_draft.md#events) | Type & Key-Value events for indexing                                             | 1            |
-    | tx_result               | repeated [TxResult](#txresult)                              | List of structures containing the data resulting from executing the transactions | 2            |
+    | tx_results              | repeated [ExecTxResult](#txresult)                          | List of structures containing the data resulting from executing the transactions | 2            |
     | validator_updates       | repeated [ValidatorUpdate](#validatorupdate)                | Changes to validator set (set voting power to 0 to remove).                      | 3            |
     | consensus_param_updates | [ConsensusParams](#consensusparams)                         | Changes to consensus-critical gas, size, and other parameters.                   | 4            |
-    | app_hash                | bytes                                                       | The Merkle root hash of the application state.                                   | 6            |
-    | retain_height           | int64                                                       | Blocks below this height may be removed. Defaults to `0` (retain all).           | 7            |
+    | app_hash                | bytes                                                       | The Merkle root hash of the application state.                                   | 5            |
+    | retain_height           | int64                                                       | Blocks below this height may be removed. Defaults to `0` (retain all).           | 6            |
 
 * **Usage**:
     * Contains a newly decided block.
@@ -602,12 +614,12 @@ from this condition, but not sure), and _p_ receives a Precommit message for rou
     * The header exactly matches the Tendermint header of the proposed block.
     * The Application can use `RequestFinalizeBlock.last_commit_info` and `RequestFinalizeBlock.byzantine_validators`
       to determine rewards and punishments for the validators.
-    * The application must execute the transactions in full, in the order they appear in `RequestFinalizeBlock.tx`,
+    * The application must execute the transactions in full, in the order they appear in `RequestFinalizeBlock.txs`,
       before returning control to Tendermint. Alternatively, it can commit the candidate state corresponding to the same block
       previously executed via `PrepareProposal` or `ProcessProposal`.
-    * `ResponseFinalizeBlock.tx_result[i].Code == 0` only if the _i_-th transaction is fully valid.
+    * `ResponseFinalizeBlock.tx_results[i].Code == 0` only if the _i_-th transaction is fully valid.
     * In next-block execution mode, the Application must provide values for `ResponseFinalizeBlock.app_hash`,
-      `ResponseFinalizeBlock.tx_result`, `ResponseFinalizeBlock.validator_updates`, and
+      `ResponseFinalizeBlock.tx_results`, `ResponseFinalizeBlock.validator_updates`, and
       `ResponseFinalizeBlock.consensus_param_updates` as a result of executing the block.
         * The values for `ResponseFinalizeBlock.validator_updates`, or
           `ResponseFinalizeBlock.consensus_param_updates` may be empty. In this case, Tendermint will keep
@@ -621,7 +633,7 @@ from this condition, but not sure), and _p_ receives a Precommit message for rou
           params for block `H+1`. For more information on the consensus parameters,
           see the [application spec entry on consensus parameters](../abci/apps.md#consensus-parameters).
     * In same-block execution mode, Tendermint will log an error and ignore values for
-      `ResponseFinalizeBlock.app_hash`, `ResponseFinalizeBlock.tx_result`, `ResponseFinalizeBlock.validator_updates`,
+      `ResponseFinalizeBlock.app_hash`, `ResponseFinalizeBlock.tx_results`, `ResponseFinalizeBlock.validator_updates`,
       and `ResponsePrepareProposal.consensus_param_updates`, as those must have been provided by `PrepareProposal`.
     * Application is expected to persist its state at the end of this call, before calling `ResponseFinalizeBlock`.
     * `ResponseFinalizeBlock.app_hash` contains an (optional) Merkle root hash of the application state.
@@ -700,19 +712,6 @@ Most of the data structures used in ABCI are shared [common data structures](../
 * **Usage**:
     * Validator identified by PubKey
     * Used to tell Tendermint to update the validator set
-
-### VoteInfo
-
-* **Fields**:
-
-    | Name              | Type                    | Description                                                  | Field Number |
-    |-------------------|-------------------------|--------------------------------------------------------------|--------------|
-    | validator         | [Validator](#validator) | A validator                                                  | 1            |
-    | signed_last_block | bool                    | Indicates whether or not the validator signed the last block | 2            |
-
-* **Usage**:
-    * Indicates whether a validator signed the last block, allowing for rewards
-    based on validator availability
 
 ### Evidence
 
@@ -794,9 +793,25 @@ Most of the data structures used in ABCI are shared [common data structures](../
     `Metadata`). Chunks may be retrieved from all nodes that have the same snapshot.
     * When sent across the network, a snapshot message can be at most 4 MB.
 
-## Data types introduced in ABCI++
+## Data types introduced or modified in ABCI++
 
-### TxResult
+### VoteInfo
+
+* **Fields**:
+
+    | Name                        | Type                    | Description                                                   | Field Number |
+    |-----------------------------|-------------------------|---------------------------------------------------------------|--------------|
+    | validator                   | [Validator](#validator) | A validator                                                   | 1            |
+    | signed_last_block           | bool                    | Indicates whether or not the validator signed the last block  | 2            |
+    | tendermint_signed_extension | bytes                   | Indicates whether or not the validator signed the last block  | 3            |
+    | app_signed_extension        | bytes                   | Indicates whether or not the validator signed the last block  | 3            |
+
+* **Usage**:
+    * Indicates whether a validator signed the last block, allowing for rewards
+    based on validator availability
+    * `tendermint_signed_extension` conveys the part of the validator's vote extension that was signed by Tendermint.
+    * `app_signed_extension` conveys the optional *app_signed* part of the validator's vote extension.
+### ExecTxResult
 
 * **Fields**:
 
@@ -815,21 +830,22 @@ Most of the data structures used in ABCI are shared [common data structures](../
 
 ```protobuf
   enum TxAction {
-    UNKNOWN       = 0;  // Unknown action
-    UNMODIFIED    = 1;  // The Application did not modify this transaction. Ignore new_hashes field
-    ADDED         = 2;  // The Application added this transaction. Ignore new_hashes field
-    REMOVED       = 3;  // The Application wants this transaction removed from the proposal and the mempool. Use new_hashes field if the transaction was modified
+    TXUNKNOWN    = 0;  // Unknown action
+    TXUNMODIFIED = 1;  // The Application did not modify this transaction. Ignore new_hashes field
+    TXADDED      = 2;  // The Application added this transaction. Ignore new_hashes field
+    TXREMOVED    = 3;  // The Application wants this transaction removed from the proposal and the mempool.
+                       // Use new_hashes field if the transaction was modified
   }
 ```
 
 * **Usage**:
-    * If `Action` is UNKNOWN, a problem happened in the Application. Tendermint will ignore this transaction. **TODO** should we panic?
-    * If `Action` is UNMODIFIED, Tendermint includes the transaction in the proposal. Nothing to do on the mempool. Field `new_hashes` is ignored.
-    * If `Action` is ADDED, Tendermint includes the transaction in the proposal. The transaction is also added to the mempool and gossipped. Field `new_hashes` is ignored.
-    * If `Action` is REMOVED, Tendermint excludes the transaction from the proposal. The transaction is also removed from the mempool if it exists,
+    * If `Action` is TXUNKNOWN, a problem happened in the Application. Tendermint will ignore this transaction. **TODO** should we panic?
+    * If `Action` is TXUNMODIFIED, Tendermint includes the transaction in the proposal. Nothing to do on the mempool. Field `new_hashes` is ignored.
+    * If `Action` is TXADDED, Tendermint includes the transaction in the proposal. The transaction is also added to the mempool and gossipped. Field `new_hashes` is ignored.
+    * If `Action` is TXREMOVED, Tendermint excludes the transaction from the proposal. The transaction is also removed from the mempool if it exists,
       similar to `CheckTx` returning _false_. Tendermint can use field `new_hashes` to help clients trace transactions that have been modified into other transactions.
 
-### TransactionRecord
+### TxRecord
 
 * **Fields**:
 
@@ -840,19 +856,21 @@ Most of the data structures used in ABCI are shared [common data structures](../
     | new_hashes | repeated bytes        | List of hashes of successor transactions                         | 3            |
 
 * **Usage**:
-    * As `new_hashes` is a list, `TransactionRecord` allows to trace many-to-many modifications. Some examples:
+    * The hashes contained in `new_hashes` MUST follow the same algorithm used by Tendermint for hashing transactions
+      that are in the mempool.
+    * As `new_hashes` is a list, `TxRecord` allows to trace many-to-many modifications. Some examples:
         * Transaction $t1$ modified into $t2$ is represented with these records
             * $t2$ "ADDED"
             * $t1$ "REMOVED"; `new_hashes` contains [$id(t2)$]
-        * Transaction $t1$ modified into $t2$ and $t3$ is represented with these `TransactionRecord` records
+        * Transaction $t1$ modified into $t2$ and $t3$ is represented with these `TxRecord` records
             * $t2$ "ADDED"
             * $t3$ "ADDED"
             * $t1$ "REMOVED"; `new_hashes` contains [$id(t2)$, $id(t3)$]
-        * Transactions $t1$ and $t2$ aggregated into $t3$ is represented with these `TransactionRecord` records
+        * Transactions $t1$ and $t2$ aggregated into $t3$ is represented with these `TxRecord` records
             * $t3$ "ADDED"
             * $t1$ "REMOVED"; `new_hashes` contains [$id(t3)$]
             * $t2$ "REMOVED"; `new_hashes` contains [$id(t3)$]
-        * Transactions $t1$ and $t2$ combined into $t3$ and $t4$ is represented with these `TransactionRecord` records
+        * Transactions $t1$ and $t2$ combined into $t3$ and $t4$ is represented with these `TxRecord` records
             * $t3$ "ADDED"
             * $t4$ "ADDED"
             * $t1$ "REMOVED" and `new_hashes` containing [$id(t3)$, $id(t4)$]

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -737,7 +737,8 @@ Most of the data structures used in ABCI are shared [common data structures](../
     | evidence  | [EvidenceParams](../core/data_structures.md#evidenceparams)   | Parameters limiting the validity of evidence of byzantine behaviour.         | 2            |
     | validator | [ValidatorParams](../core/data_structures.md#validatorparams) | Parameters limiting the types of public keys validators can use.             | 3            |
     | version   | [VersionsParams](../core/data_structures.md#versionparams)       | The ABCI application version.                                                | 4            |
-    | synchrony  | [SynchronyParams](../core/data_structures.md#synchronyparams)   | Parameters that determine the bounds under which a proposed block's timestamp is considered valid.                                                | 4            |
+    | synchrony | [SynchronyParams](../core/data_structures.md#synchronyparams)   | Parameters that determine the bounds under which a proposed block's timestamp is considered valid.   | 5            |
+    | timeout   | [TimeoutParams](../core/data_structures.md#timeoutparams)   | Parameters that configure the timeouts for the steps of the Tendermint consensus algorithm. | 6            |
 
 ### ProofOps
 

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -737,6 +737,7 @@ Most of the data structures used in ABCI are shared [common data structures](../
     | evidence  | [EvidenceParams](../core/data_structures.md#evidenceparams)   | Parameters limiting the validity of evidence of byzantine behaviour.         | 2            |
     | validator | [ValidatorParams](../core/data_structures.md#validatorparams) | Parameters limiting the types of public keys validators can use.             | 3            |
     | version   | [VersionsParams](../core/data_structures.md#versionparams)       | The ABCI application version.                                                | 4            |
+    | synchrony  | [SynchronyParams](../core/data_structures.md#synchronyparams)   | Parameters that determine the bounds under which a proposed block's timestamp is considered valid.                                                | 4            |
 
 ### ProofOps
 

--- a/spec/consensus/proposer-based-timestamp/README.md
+++ b/spec/consensus/proposer-based-timestamp/README.md
@@ -1,20 +1,157 @@
-# Proposer-Based Timestamps
+# Proposer-Based Timestamps (PBTS)
 
-This section describes a version of the Tendermint consensus protocol,
-which uses proposer-based timestamps.
+This section describes a version of the Tendermint consensus protocol
+that uses proposer-based timestamps.
 
-## Contents
+## Context
 
-- [Proposer-Based Time][main] (entry point)
-- [Part I - System Model and Properties][sysmodel]
-- [Part II - Protocol Specification][algorithm]
-- [TLA+ Specification][proposertla]
+Tendermint provides a deterministic, Byzantine fault-tolerant, source of time,
+defined by the `Time` field present in the headers of committed blocks.
 
+In the current consensus implementation, the timestamp of a block is
+computed by the [`BFTTime`][bfttime] algorithm:
+
+- Validators include a timestamp in the `Precommit` messages they broadcast.
+Timestamps are retrieved from the validators' local clocks,
+with the only restriction that they must be **monotonic**:
+
+    - The timestamp of a `Precommit` message voting for a block
+	cannot be earlier than the `Time` field of that block;
+
+- The timestamp of a block is deterministically computed from the timestamps of
+a set of `Precommit` messages that certify the commit of the previous block.
+This certificate, a set of `Precommit` messages from a round of the previous height,
+is selected by the block's proposer and stored in the `Commit` field of the block:
+
+    - The block timestamp is the *median* of the timestamps of the `Precommit` messages
+	included in the `Commit` field, weighted by their voting power.
+	Block timestamps are **monotonic** because
+	timestamps of valid `Precommit` messages are monotonic;
+
+Assuming that the voting power controlled by Byzantine validators is bounded by `f`,
+the cumulative voting power of any valid `Commit` set must be at least `2f+1`.
+As a result, the timestamp computed by `BFTTime` is not influenced by Byzantine validators,
+as the weighted median of `Commit` timestamps comes from the clock of a non-faulty validator.
+
+Tendermint does not make any assumptions regarding the clocks of (correct) validators,
+as block timestamps have no impact in the consensus protocol.
+However, the `Time` field of committed blocks is used by other components of Tendermint,
+such as IBC, the evidence, staking, and slashing modules.
+And it is used based on the common belief that block timestamps
+should bear some resemblance to real time, which is **not guaranteed**.
+
+A more comprehensive discussion of the limitations of `BFTTime`
+can be found in the [first draft][main_v1] of this proposal.
+Of particular interest is to possibility of having validators equipped with "faulty" clocks,
+not fairly accurate with real time, that control more than `f` voting power,
+plus the proposer's flexibility when selecting a `Commit` set,
+and thus determining the timestamp for a block.
+
+## Proposal
+
+In the proposed solution, the timestamp of a block is assigned by its
+proposer, according with its local clock.
+In other words, the proposer of a block also *proposes* a timestamp for the block.
+Validators can accept or reject a proposed block.
+A block is only accepted if its timestamp is acceptable.
+A proposed timestamp is acceptable if it is *received* within a certain time window,
+determined by synchronous parameters.
+
+PBTS therefore augments the system model considered by Tendermint with *synchronous assumptions*:
+
+- **Synchronized clocks**: simultaneous clock reads at any two correct validators
+differ by at most `PRECISION`;
+
+- **Bounded message delays**: the end-to-end delay for delivering a message to all correct validators
+is bounded by `MSGDELAY`.
+This assumption is restricted to `Proposal` messages, broadcast by proposers.
+
+`PRECISION` and `MSGDELAY` are consensus parameters, shared by all validators,
+that define whether the timestamp of a block is acceptable.
+Let `t` be the time, read from its local clock, at which a validator
+receives, for the first time, a proposal with timestamp `ts`:
+
+- **[Time-Validity]** The proposed timestamp `ts` received at local time `t`
+is accepted if it satisfies the **timely** predicate:
+	> `ts - PRECISION <= t <= ts + MSGDELAY + PRECISION`
+
+The left inequality of the *timely* predicate establishes that proposed timestamps
+should be in the past, when adjusted by the clocks `PRECISION`.
+The right inequality of the *timely* predicate establishes that proposed timestamps
+should not be too much in the past, more precisely, not more than `MSGDELAY` in the past,
+when adjusted by the clocks `PRECISION`.
+
+A more detailed and formalized description is available in the
+[System Model and Properties][sysmodel] document
+
+## Implementation
+
+The implementation of PBTS requires some changes in Tendermint consensus algorithm,
+summarized below:
+
+- A proposer timestamps a block with the current time, read from its local clock.
+The block's timestamp represents the time at which it was assembled
+(after the `getValue()` call in line 18 of the [arXiv][arXiv] algorithm):
+
+    - Block timestamps are definitive, meaning that the original timestamp
+	is retained when a block is re-proposed (line 16);
+
+    - To preserve monotonicity, a proposer might need to wait until its clock
+	reads a time greater than the timestamp of the previous block;
+
+- A validator only prevotes for *timely* blocks,
+that is, blocks whose timestamps are considered *timely* (compared to the original Tendermint consensus, a check is added to line 23).
+If the block proposed in a round is considered *untimely*,
+the validator prevotes `nil` (line 26):
+
+    - Validators register the time at which they received `Proposal` messages,
+	in order to evaluate the *timely* predicate;
+
+    - Blocks that are re-proposed because they received `2f+1 Prevotes`
+	in a previous round (line 28) are not subject to the *timely* predicate,
+	as they have already been evaluated as *timely* at a previous round.
+
+The more complex change proposed regards blocks that can be re-proposed in multiple rounds.
+The current solution improves the [first version of the specification][algorithm_v1] (that never had been implemented)
+by simplifying the way this situation is handled,
+from a recursive reasoning regarding valid blocks that are re-proposed.
+
+The full solution is detailed and formalized in the [Protocol Specification][algorithm] document.
+
+## Further details
+
+- [System Model and Properties][sysmodel]
+- [Protocol Specification][algorithm]
+- [TLA+ Specification][proposertla] (first draft, not updated)
+
+### Open issues
+
+- [PBTS: evidence #355][issue355]: not really clear the context, probably not going to be solved.
+- [PBTS: should synchrony parameters be adaptive? #371][issue371]
+- [PBTS: Treat proposal and block parts explicitly in the spec #372][issue372]
+- [PBTS: margins for proposal times assigned by Byzantine proposers #377][issue377]
+
+### Closed issues
+
+- [Proposer time - fix message filter condition #353][issue353]
+- [PBTS: association between timely predicate and timeout_commit #370][issue370]
+
+[main_v1]: ./v1/pbts_001_draft.md
 
 [algorithm]: ./pbts-algorithm_002_draft.md
+[algorithm_v1]: ./v1/pbts-algorithm_001_draft.md
 
-[sysmodel]: ./pbts-sysmodel_001_draft.md
-
-[main]: ./pbts_001_draft.md
+[sysmodel]: ./pbts-sysmodel_002_draft.md
+[sysmodel_v1]: ./v1/pbts-sysmodel_001_draft.md
 
 [proposertla]: ./tla/TendermintPBT_001_draft.tla
+
+[bfttime]: https://github.com/tendermint/spec/blob/master/spec/consensus/bft-time.md
+[arXiv]: https://arxiv.org/pdf/1807.04938.pdf
+
+[issue353]: https://github.com/tendermint/spec/issues/353
+[issue355]: https://github.com/tendermint/spec/issues/355
+[issue370]: https://github.com/tendermint/spec/issues/370
+[issue371]: https://github.com/tendermint/spec/issues/371
+[issue372]: https://github.com/tendermint/spec/issues/372
+[issue377]: https://github.com/tendermint/spec/issues/377

--- a/spec/consensus/proposer-based-timestamp/pbts-algorithm_002_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts-algorithm_002_draft.md
@@ -1,4 +1,4 @@
-# Proposer-Based Time v2 - Part II
+# PBTS: Protocol Specification
 
 ## Proposal Time
 
@@ -6,7 +6,7 @@ PBTS computes for a proposed value `v` the proposal time `v.time`, with bounded 
 The proposal time is read from the clock of the process that proposes a value for the first time, its original proposer.
 
 With PBTS, therefore, we assume that processes have access to **synchronized clocks**.
-The proper definition of what it means can be found in the [system model][model],
+The proper definition of what it means can be found in the [system model][sysmodel],
 but essentially we assume that two correct processes do not simultaneous read from their clocks
 time values that differ more than `PRECISION`, which is a system parameter.
 
@@ -20,7 +20,7 @@ A value `v` should re-proposed when it becomes locked by the network, i.e., when
 This means that processes with `2f + 1`-equivalent voting power accepted, in round `r`, both `v` and its associated time `v.time`.
 Since the originally proposed value and its associated time were considered valid, there is no reason for reassigning `v.time`.
 
-In the [first version][v1] of this specification, proposals were defined as pairs `(v, time)`.
+In the [first version][algorithm_v1] of this specification, proposals were defined as pairs `(v, time)`.
 In addition, the same value `v` could be proposed, in different rounds, but would be associated to distinct times each time it was reproposed.
 Since this possibility does not exist in this second specification, the proposal time became part of the proposed value.
 With this simplification, several small changes to the [arXiv][arXiv] algorithm are no longer required.
@@ -38,8 +38,8 @@ it should postpone the generation of its proposal until `now_p > decision_p[h_p-
 > Although it should be considered, this scenario is unlikely during regular operation,
 as from `decision_p[h_p-1].time` and the start of height `h_p`, a complete consensus instance need to terminate.
 
-Notice that monotonicity is not introduced by this proposal, being already ensured by [`bfttime`][bfttime].
-In `bfttime`, the `Timestamp` field of every `Precommit` message of height `h_p` sent by a correct process is required to be larger than `decision_p[h_p-1].time`, as one of such `Timestamp` fields becomes the time assigned to a value proposed at height `h_p`.
+Notice that monotonicity is not introduced by this proposal, being already ensured by  [`BFTTime`][bfttime].
+In `BFTTime`, the `Timestamp` field of every `Precommit` message of height `h_p` sent by a correct process is required to be larger than `decision_p[h_p-1].time`, as one of such `Timestamp` fields becomes the time assigned to a value proposed at height `h_p`.
 
 The time monotonicity of values proposed in heights of consensus is verified by the `valid()` predicate, to which every proposed value is submitted.
 A value rejected by the `valid()` implementation is not accepted by any correct process.
@@ -48,7 +48,7 @@ A value rejected by the `valid()` implementation is not accepted by any correct 
 
 PBTS introduces a new requirement for a process to accept a proposal: the proposal must be `timely`.
 It is a temporal requirement, associated with the following synchrony (that is, timing)
-[assumptions][model] regarding the behavior of processes and the network:
+[assumptions][sysmodel] regarding the behavior of processes and the network:
 
 - Synchronized clocks: the values simultaneously read from clocks of any two correct processes differ by at most `PRECISION`;
 - Bounded transmission delays: the real time interval between the sending of a proposal at a correct process, and the reception of the proposal at any correct process is upper bounded by `MSGDELAY`.
@@ -138,8 +138,11 @@ and because, since `v` was re-proposed as a `validValue` (line 16), `v.time` has
 
 Back to [main document][main].
 
-[arXiv]: https://arxiv.org/abs/1807.04938
-[v1]: ./pbts-algorithm_001_draft.md
-[main]: ./pbts_001_draft.md
-[bfttime]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/spec/consensus/bft-time.md
-[model]: ./pbts-sysmodel_002_draft.md
+[main]: ./README.md
+
+[algorithm_v1]: ./v1/pbts-algorithm_001_draft.md
+
+[sysmodel]: ./pbts-sysmodel_002_draft.md
+
+[bfttime]: https://github.com/tendermint/spec/blob/master/spec/consensus/bft-time.md
+[arXiv]: https://arxiv.org/pdf/1807.04938.pdf

--- a/spec/consensus/proposer-based-timestamp/pbts-sysmodel_002_draft.md
+++ b/spec/consensus/proposer-based-timestamp/pbts-sysmodel_002_draft.md
@@ -1,4 +1,4 @@
-# Proposer-Based Time v2 - Part I
+# PBTS: System Model and Properties
 
 ## System Model
 
@@ -37,7 +37,7 @@ from their local clocks, so that their clocks can be considered synchronized.
 
 #### Accuracy
 
-The [original specification][v1] included a second clock-related parameter, `ACCURACY`,
+The [first draft][sysmodel_v1] of this specification included a second clock-related parameter, `ACCURACY`,
 that relates the values read by processes from their synchronized clocks with real time:
 
 - If `p` is a process is equipped with a synchronized clock, then at real time
@@ -248,6 +248,11 @@ The precise behavior for this workaround is under [discussion](https://github.co
 
 Back to [main document][main].
 
-[main]: ./pbts_001_draft.md
-[v1]: ./pbts-sysmodel_001_draft.md
-[arXiv]: https://arxiv.org/abs/1807.04938
+[main]: ./README.md
+
+[algorithm]: ./pbts-algorithm_002_draft.md
+
+[sysmodel]: ./pbts-sysmodel_002_draft.md
+[sysmodel_v1]: ./v1/pbts-sysmodel_001_draft.md
+
+[arXiv]: https://arxiv.org/pdf/1807.04938.pdf

--- a/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_002_draft.tla
+++ b/spec/consensus/proposer-based-timestamp/tla/TendermintPBT_002_draft.tla
@@ -1,0 +1,779 @@
+-------------------- MODULE TendermintPBT_002_draft ---------------------------
+(*
+ A TLA+ specification of a simplified Tendermint consensus, with added clocks 
+ and proposer-based timestamps. This TLA+ specification extends and modifies 
+ the Tendermint TLA+ specification for fork accountability: 
+    https://github.com/tendermint/spec/blob/master/spec/light-client/accountability/TendermintAcc_004_draft.tla
+ 
+ * Version 1. A preliminary specification.
+
+ Zarko Milosevic, Igor Konnov, Informal Systems, 2019-2020.
+ Ilina Stoilkovska, Josef Widder, Informal Systems, 2021.
+ *)
+
+EXTENDS Integers, FiniteSets, Apalache, typedefs
+
+(********************* PROTOCOL PARAMETERS **********************************)
+\* General protocol parameters
+CONSTANTS
+  \* @type: Set(PROCESS);
+  Corr,          \* the set of correct processes 
+  \* @type: Set(PROCESS);
+  Faulty,        \* the set of Byzantine processes, may be empty
+  \* @type: Int;  
+  N,             \* the total number of processes: correct, defective, and Byzantine
+  \* @type: Int;  
+  T,             \* an upper bound on the number of Byzantine processes
+  \* @type: Set(VALUE);  
+  ValidValues,   \* the set of valid values, proposed both by correct and faulty
+  \* @type: Set(VALUE);  
+  InvalidValues, \* the set of invalid values, never proposed by the correct ones
+  \* @type: ROUND;    
+  MaxRound,      \* the maximal round number
+  \* @type: ROUND -> PROCESS;
+  Proposer       \* the proposer function from Rounds to AllProcs
+
+\* Time-related parameters
+CONSTANTS
+  \* @type: TIME;
+  MaxTimestamp,  \* the maximal value of the clock tick
+  \* @type: TIME;
+  Delay,         \* message delay
+  \* @type: TIME;
+  Precision,     \* clock precision: the maximal difference between two local clocks  
+  \* @type: TIME;
+  Accuracy,      \* clock accuracy: the maximal difference between a local clock and the real time
+  \* @type: Bool;
+  ClockDrift     \* is there clock drift between the local clocks and the global clock
+
+ASSUME(N = Cardinality(Corr \union Faulty))
+
+(*************************** DEFINITIONS ************************************)
+\* @type: Set(PROCESS);
+AllProcs == Corr \union Faulty      \* the set of all processes
+\* @type: Set(ROUND);
+Rounds == 0..MaxRound               \* the set of potential rounds
+\* @type: Set(TIME);
+Timestamps == 0..MaxTimestamp       \* the set of clock ticks
+\* @type: ROUND;
+NilRound == -1   \* a special value to denote a nil round, outside of Rounds
+\* @type: TIME;
+NilTimestamp == -1 \* a special value to denote a nil timestamp, outside of Ticks
+\* @type: Set(ROUND);
+RoundsOrNil == Rounds \union {NilRound}
+\* @type: Set(VALUE);
+Values == ValidValues \union InvalidValues \* the set of all values
+\* @type: VALUE;
+NilValue == "None"  \* a special value for a nil round, outside of Values
+\* @type: Set(PROPOSAL);
+Proposals == Values \X Timestamps
+\* @type: PROPOSAL;
+NilProposal == <<NilValue, NilTimestamp>>
+\* @type: Set(VALUE);
+ValuesOrNil == Values \union {NilValue}
+\* @type: Set(DECISION);
+Decisions == Values \X Timestamps \X Rounds
+\* @type: DECISION;
+NilDecision == <<NilValue, NilTimestamp, NilRound>>
+
+
+\* a value hash is modeled as identity
+\* @type: (t) => t;
+Id(v) == v
+
+\* The validity predicate
+\* @type: (VALUE) => Bool;
+IsValid(v) == v \in ValidValues
+
+\* the two thresholds that are used in the algorithm
+\* @type: Int;
+THRESHOLD1 == T + 1     \* at least one process is not faulty
+\* @type: Int;
+THRESHOLD2 == 2 * T + 1 \* a quorum when having N > 3 * T
+
+\* @type: (Set(TIME)) => TIME;
+Min(S) == CHOOSE x \in S : \A y \in S : x <= y
+
+\* @type: (Set(TIME)) => TIME;
+Max(S) == CHOOSE x \in S : \A y \in S : y <= x
+
+(********************* TYPE ANNOTATIONS FOR APALACHE **************************)
+
+\* a type annotation for an empty set of messages
+\* @type: Set(MESSAGE);
+EmptyMsgSet == {}
+
+\* @type: Set(RCVPROP);
+EmptyRcvProp == {}
+
+\* @type: Set(PROCESS);
+EmptyProcSet == {}
+
+(********************* PROTOCOL STATE VARIABLES ******************************)
+VARIABLES
+  \* @type: PROCESS -> ROUND;
+  round,    \* a process round number
+  \* @type: PROCESS -> STEP;
+  step,     \* a process step
+  \* @type: PROCESS -> DECISION;
+  decision, \* process decision
+  \* @type: PROCESS -> VALUE;
+  lockedValue,  \* a locked value
+  \* @type: PROCESS -> ROUND;
+  lockedRound,  \* a locked round
+  \* @type: PROCESS -> VALUE;
+  validValue,   \* a valid value
+  \* @type: PROCESS -> ROUND;
+  validRound    \* a valid round
+
+\* time-related variables
+VARIABLES  
+  \* @type: PROCESS -> TIME;
+  localClock, \* a process local clock: Corr -> Ticks
+  \* @type: TIME;
+  realTime   \* a reference Newtonian real time
+
+\* book-keeping variables
+VARIABLES
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose,   \* PROPOSE messages broadcast in the system, Rounds -> Messages
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote,   \* PREVOTE messages broadcast in the system, Rounds -> Messages
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, \* PRECOMMIT messages broadcast in the system, Rounds -> Messages
+  \* @type: Set(MESSAGE);
+  evidence, \* the messages that were used by the correct processes to make transitions
+  \* @type: ACTION;
+  action,       \* we use this variable to see which action was taken
+  \* @type: Set(RCVPROP);
+  receivedTimelyProposal, \* used to keep track when a process receives a timely PROPOSAL message
+  \* @type: ROUND -> Set(PROCESS);
+  inspectedProposal, \* used to keep track when a process tries to receive a message
+  \* @type: TIME;
+  beginConsensus, \* the minimum of the local clocks in the initial state
+  \* @type: PROCESS -> TIME;
+  endConsensus, \* the local time when a decision is made
+  \* @type: TIME;
+  lastBeginConsensus, \* the maximum of the local clocks in the initial state
+  \* @type: ROUND -> TIME;
+  proposalTime, \* the real time when a proposer proposes in a round
+  \* @type: ROUND -> TIME;
+  proposalReceivedTime \* the real time when a correct process first receives a proposal message in a round
+
+(* to see a type invariant, check TendermintAccInv3 *)  
+ 
+\* a handy definition used in UNCHANGED
+vars == <<round, step, decision, lockedValue, lockedRound,
+          validValue, validRound, evidence, msgsPropose, msgsPrevote, msgsPrecommit,
+          localClock, realTime, receivedTimelyProposal, inspectedProposal, action,
+          beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+
+(********************* PROTOCOL INITIALIZATION ******************************)
+\* @type: (ROUND) => Set(PROPMESSAGE);
+FaultyProposals(r) ==
+  [
+    type      : {"PROPOSAL"}, 
+    src       : Faulty,
+    round     : {r}, 
+    proposal  : Proposals, 
+    validRound: RoundsOrNil
+  ]
+
+\* @type: Set(PROPMESSAGE);
+AllFaultyProposals ==
+  [
+    type      : {"PROPOSAL"}, 
+    src       : Faulty,
+    round     : Rounds, 
+    proposal  : Proposals, 
+    validRound: RoundsOrNil
+  ]
+
+\* @type: (ROUND) => Set(PREMESSAGE);
+FaultyPrevotes(r) ==
+  [
+    type : {"PREVOTE"}, 
+    src  : Faulty, 
+    round: {r}, 
+    id   : Proposals
+  ]
+
+\* @type: Set(PREMESSAGE);
+AllFaultyPrevotes ==    
+  [
+    type : {"PREVOTE"}, 
+    src  : Faulty, 
+    round: Rounds, 
+    id   : Proposals
+  ]
+
+\* @type: (ROUND) => Set(PREMESSAGE);
+FaultyPrecommits(r) ==
+  [
+    type : {"PRECOMMIT"}, 
+    src  : Faulty, 
+    round: {r}, 
+    id   : Proposals
+  ]
+
+\* @type: Set(PREMESSAGE);
+AllFaultyPrecommits ==
+  [
+    type : {"PRECOMMIT"}, 
+    src  : Faulty, 
+    round: Rounds, 
+    id   : Proposals
+  ]
+
+\* @type: Set(PROPMESSAGE);
+AllProposals ==
+  [
+    type      : {"PROPOSAL"}, 
+    src       : AllProcs,
+    round     : Rounds, 
+    proposal  : Proposals, 
+    validRound: RoundsOrNil
+  ]    
+
+\* @type: (ROUND) => Set(PROPMESSAGE);
+RoundProposals(r) ==
+  [
+    type      : {"PROPOSAL"}, 
+    src       : AllProcs,
+    round     : {r}, 
+    proposal  : Proposals, 
+    validRound: RoundsOrNil
+  ]
+
+\* @type: (ROUND -> Set(MESSAGE)) => Bool;
+BenignRoundsInMessages(msgfun) ==
+  \* the message function never contains a message for a wrong round
+  \A r \in Rounds:
+    \A m \in msgfun[r]:
+      r = m.round
+
+\* The initial states of the protocol. Some faults can be in the system already.
+Init ==
+    /\ round = [p \in Corr |-> 0]
+    /\ \/ /\ ~ClockDrift
+          /\ localClock \in [Corr -> 0..Accuracy]
+       \/ /\ ClockDrift
+          /\ localClock = [p \in Corr |-> 0]
+    /\ realTime = 0
+    /\ step = [p \in Corr |-> "PROPOSE"]
+    /\ decision = [p \in Corr |-> NilDecision]
+    /\ lockedValue = [p \in Corr |-> NilValue]
+    /\ lockedRound = [p \in Corr |-> NilRound]
+    /\ validValue = [p \in Corr |-> NilValue]
+    /\ validRound = [p \in Corr |-> NilRound]
+    /\ msgsPropose \in [Rounds -> SUBSET AllFaultyProposals]
+    /\ msgsPrevote \in [Rounds -> SUBSET AllFaultyPrevotes]
+    /\ msgsPrecommit \in [Rounds -> SUBSET AllFaultyPrecommits]
+    /\ receivedTimelyProposal = EmptyRcvProp
+    /\ inspectedProposal = [r \in Rounds |-> EmptyProcSet]
+    /\ BenignRoundsInMessages(msgsPropose)
+    /\ BenignRoundsInMessages(msgsPrevote)
+    /\ BenignRoundsInMessages(msgsPrecommit)
+    /\ evidence = EmptyMsgSet
+    /\ action' = "Init"
+    /\ beginConsensus = Min({localClock[p] : p \in Corr})
+    /\ endConsensus = [p \in Corr |-> NilTimestamp]
+    /\ lastBeginConsensus = Max({localClock[p] : p \in Corr})
+    /\ proposalTime = [r \in Rounds |-> NilTimestamp]
+    /\ proposalReceivedTime = [r \in Rounds |-> NilTimestamp]
+
+(************************ MESSAGE PASSING ********************************)
+\* @type: (PROCESS, ROUND, PROPOSAL, ROUND) => Bool;
+BroadcastProposal(pSrc, pRound, pProposal, pValidRound) ==
+  LET 
+    \* @type: PROPMESSAGE;
+    newMsg ==
+    [
+      type       |-> "PROPOSAL", 
+      src        |-> pSrc, 
+      round      |-> pRound,
+      proposal   |-> pProposal, 
+      validRound |-> pValidRound
+    ]
+  IN
+  msgsPropose' = [msgsPropose EXCEPT ![pRound] = msgsPropose[pRound] \union {newMsg}]
+
+\* @type: (PROCESS, ROUND, PROPOSAL) => Bool;
+BroadcastPrevote(pSrc, pRound, pId) ==
+  LET 
+    \* @type: PREMESSAGE;
+    newMsg == 
+    [
+      type  |-> "PREVOTE",
+      src   |-> pSrc, 
+      round |-> pRound, 
+      id    |-> pId
+    ]
+  IN
+  msgsPrevote' = [msgsPrevote EXCEPT ![pRound] = msgsPrevote[pRound] \union {newMsg}]
+
+\* @type: (PROCESS, ROUND, PROPOSAL) => Bool;
+BroadcastPrecommit(pSrc, pRound, pId) ==
+  LET
+    \* @type: PREMESSAGE; 
+    newMsg == 
+    [
+      type  |-> "PRECOMMIT",
+      src   |-> pSrc, 
+      round |-> pRound, 
+      id    |-> pId
+    ]
+  IN
+  msgsPrecommit' = [msgsPrecommit EXCEPT ![pRound] = msgsPrecommit[pRound] \union {newMsg}]
+
+(***************************** TIME **************************************)
+
+\* [PBTS-CLOCK-PRECISION.0]
+\* @type: Bool;
+SynchronizedLocalClocks ==
+    \A p \in Corr : \A q \in Corr : 
+        p /= q => 
+            \/ /\ localClock[p] >= localClock[q]
+               /\ localClock[p] - localClock[q] < Precision 
+            \/ /\ localClock[p] < localClock[q]
+               /\ localClock[q] - localClock[p] < Precision
+    
+\* [PBTS-PROPOSE.0]
+\* @type: (VALUE, TIME) => PROPOSAL;
+Proposal(v, t) ==
+    <<v, t>>
+
+\* [PBTS-DECISION-ROUND.0]
+\* @type: (VALUE, TIME, ROUND) => DECISION;
+Decision(v, t, r) ==
+    <<v, t, r>>
+
+(**************** MESSAGE PROCESSING TRANSITIONS *************************)
+\* lines 12-13
+\* @type: (PROCESS, ROUND) => Bool;
+StartRound(p, r) ==
+   /\ step[p] /= "DECIDED" \* a decided process does not participate in consensus
+   /\ round' = [round EXCEPT ![p] = r]
+   /\ step' = [step EXCEPT ![p] = "PROPOSE"] 
+
+\* lines 14-19, a proposal may be sent later
+\* @type: (PROCESS) => Bool;
+InsertProposal(p) == 
+  LET r == round[p] IN
+  /\ p = Proposer[r]
+  /\ step[p] = "PROPOSE"
+    \* if the proposer is sending a proposal, then there are no other proposals
+    \* by the correct processes for the same round
+  /\ \A m \in msgsPropose[r]: m.src /= p
+  /\ \E v \in ValidValues: 
+      LET value == 
+        IF validValue[p] /= NilValue 
+        THEN validValue[p]
+        ELSE v
+      IN LET 
+        proposal == Proposal(value, localClock[p]) 
+      IN               
+      /\ BroadcastProposal(p, round[p], proposal, validRound[p])
+      /\ proposalTime' = [proposalTime EXCEPT ![r] = realTime]
+  /\ UNCHANGED <<evidence, round, decision, lockedValue, lockedRound,
+                validValue, step, validRound, msgsPrevote, msgsPrecommit,
+                localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                beginConsensus, endConsensus, lastBeginConsensus, proposalReceivedTime>>
+  /\ action' = "InsertProposal"
+  
+\* a new action used to filter messages that are not on time
+\* [PBTS-RECEPTION-STEP.0]
+\* @type: (PROCESS) => Bool;
+ReceiveProposal(p) ==
+  \E v \in Values, t \in Timestamps:
+    /\ LET r == round[p] IN
+       LET 
+        \* @type: PROPMESSAGE;
+        msg ==
+          [
+            type       |-> "PROPOSAL", 
+            src        |-> Proposer[round[p]],
+            round      |-> round[p], 
+            proposal   |-> Proposal(v, t), 
+            validRound |-> NilRound
+          ] 
+       IN
+      /\ msg \in msgsPropose[round[p]] 
+      /\ p \notin inspectedProposal[r]
+      /\ <<p, msg>> \notin receivedTimelyProposal
+      /\ inspectedProposal' = [inspectedProposal EXCEPT ![r] = @ \union {p}]
+      /\ \/ /\ localClock[p] - Precision < t 
+            /\ t < localClock[p] + Precision + Delay
+            /\ receivedTimelyProposal' = receivedTimelyProposal \union {<<p, msg>>}
+            /\ \/ /\ proposalReceivedTime[r] = NilTimestamp
+                  /\ proposalReceivedTime' = [proposalReceivedTime EXCEPT ![r] = realTime]
+               \/ /\ proposalReceivedTime[r] /= NilTimestamp
+                  /\ UNCHANGED proposalReceivedTime
+         \/ /\ \/ localClock[p] - Precision >= t
+               \/ t >= localClock[p] + Precision + Delay
+            /\ UNCHANGED <<receivedTimelyProposal, proposalReceivedTime>>
+      /\ UNCHANGED <<round, step, decision, lockedValue, lockedRound,
+          validValue, validRound, evidence, msgsPropose, msgsPrevote, msgsPrecommit,
+          localClock, realTime, beginConsensus, endConsensus, lastBeginConsensus, proposalTime>>
+      /\ action' = "ReceiveProposal"
+      
+\* lines 22-27
+\* @type: (PROCESS) => Bool;
+UponProposalInPropose(p) ==
+  \E v \in Values, t \in Timestamps:
+    /\ step[p] = "PROPOSE" (* line 22 *)
+    /\ LET 
+        \* @type: PROPMESSAGE; 
+        msg ==
+        [
+          type       |-> "PROPOSAL", 
+          src        |-> Proposer[round[p]],
+          round      |-> round[p], 
+          proposal   |-> Proposal(v, t), 
+          validRound |-> NilRound
+        ] 
+       IN
+      /\ <<p, msg>> \in receivedTimelyProposal \* updated line 22
+      /\ evidence' = {msg} \union evidence
+    /\ LET mid == (* line 23 *)
+         IF IsValid(v) /\ (lockedRound[p] = NilRound \/ lockedValue[p] = v)
+         THEN Id(Proposal(v, t))
+         ELSE NilProposal
+       IN
+       BroadcastPrevote(p, round[p], mid) \* lines 24-26
+    /\ step' = [step EXCEPT ![p] = "PREVOTE"]
+    /\ UNCHANGED <<round, decision, lockedValue, lockedRound,
+                   validValue, validRound, msgsPropose, msgsPrecommit,
+                   localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                   beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+    /\ action' = "UponProposalInPropose"
+
+\* lines 28-33        
+\* [PBTS-ALG-OLD-PREVOTE.0]
+\* @type: (PROCESS) => Bool;
+UponProposalInProposeAndPrevote(p) ==
+  \E v \in Values, t1 \in Timestamps, t2 \in Timestamps, vr \in Rounds:
+    /\ step[p] = "PROPOSE" /\ 0 <= vr /\ vr < round[p] \* line 28, the while part
+    /\ LET 
+        \* @type: PROPMESSAGE; 
+        msg ==
+        [
+          type       |-> "PROPOSAL", 
+          src        |-> Proposer[round[p]],
+          round      |-> round[p], 
+          proposal   |-> Proposal(v, t1), 
+          validRound |-> vr
+        ]
+       IN
+       /\ <<p, msg>> \in receivedTimelyProposal \* updated line 28
+       /\ LET PV == { m \in msgsPrevote[vr]: m.id = Id(Proposal(v, t2)) } IN
+          /\ Cardinality(PV) >= THRESHOLD2 \* line 28
+          /\ evidence' = PV \union {msg} \union evidence
+    /\ LET mid == (* line 29 *)
+         IF IsValid(v) /\ (lockedRound[p] <= vr \/ lockedValue[p] = v)
+         THEN Id(Proposal(v, t1)) 
+         ELSE NilProposal 
+       IN
+       BroadcastPrevote(p, round[p], mid) \* lines 24-26
+    /\ step' = [step EXCEPT ![p] = "PREVOTE"]
+    /\ UNCHANGED <<round, decision, lockedValue, lockedRound,
+                   validValue, validRound, msgsPropose, msgsPrecommit,
+                   localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                   beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+    /\ action' = "UponProposalInProposeAndPrevote"
+                     
+\* lines 34-35 + lines 61-64 (onTimeoutPrevote)
+\* @type: (PROCESS) => Bool;
+UponQuorumOfPrevotesAny(p) ==
+  /\ step[p] = "PREVOTE" \* line 34 and 61
+  /\ \E MyEvidence \in SUBSET msgsPrevote[round[p]]:
+      \* find the unique voters in the evidence
+      LET Voters == { m.src: m \in MyEvidence } IN
+      \* compare the number of the unique voters against the threshold
+      /\ Cardinality(Voters) >= THRESHOLD2 \* line 34
+      /\ evidence' = MyEvidence \union evidence
+      /\ BroadcastPrecommit(p, round[p], NilProposal)
+      /\ step' = [step EXCEPT ![p] = "PRECOMMIT"]
+      /\ UNCHANGED <<round, decision, lockedValue, lockedRound,
+                    validValue, validRound, msgsPropose, msgsPrevote,
+                    localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                    beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+      /\ action' = "UponQuorumOfPrevotesAny"
+                     
+\* lines 36-46
+\* [PBTS-ALG-NEW-PREVOTE.0]
+\* @type: (PROCESS) => Bool;
+UponProposalInPrevoteOrCommitAndPrevote(p) ==
+  \E v \in ValidValues, t \in Timestamps, vr \in RoundsOrNil:
+    /\ step[p] \in {"PREVOTE", "PRECOMMIT"} \* line 36
+    /\ LET
+        \* @type: PROPMESSAGE; 
+        msg ==
+        [
+          type       |-> "PROPOSAL", 
+          src        |-> Proposer[round[p]],
+          round      |-> round[p], 
+          proposal   |-> Proposal(v, t), 
+          validRound |-> vr
+        ] 
+       IN 
+        /\ <<p, msg>> \in receivedTimelyProposal \* updated line 36
+        /\ LET PV == { m \in msgsPrevote[round[p]]: m.id = Id(Proposal(v, t)) } IN
+          /\ Cardinality(PV) >= THRESHOLD2 \* line 36
+          /\ evidence' = PV \union {msg} \union evidence
+    /\  IF step[p] = "PREVOTE"
+        THEN \* lines 38-41:
+          /\ lockedValue' = [lockedValue EXCEPT ![p] = v]
+          /\ lockedRound' = [lockedRound EXCEPT ![p] = round[p]]
+          /\ BroadcastPrecommit(p, round[p], Id(Proposal(v, t)))
+          /\ step' = [step EXCEPT ![p] = "PRECOMMIT"]
+        ELSE
+          UNCHANGED <<lockedValue, lockedRound, msgsPrecommit, step>>
+      \* lines 42-43
+    /\ validValue' = [validValue EXCEPT ![p] = v]
+    /\ validRound' = [validRound EXCEPT ![p] = round[p]]
+    /\ UNCHANGED <<round, decision, msgsPropose, msgsPrevote,
+                  localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                  beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+    /\ action' = "UponProposalInPrevoteOrCommitAndPrevote"
+
+\* lines 47-48 + 65-67 (onTimeoutPrecommit)
+\* @type: (PROCESS) => Bool;
+UponQuorumOfPrecommitsAny(p) ==
+  /\ \E MyEvidence \in SUBSET msgsPrecommit[round[p]]:
+      \* find the unique committers in the evidence
+      LET Committers == { m.src: m \in MyEvidence } IN
+      \* compare the number of the unique committers against the threshold
+      /\ Cardinality(Committers) >= THRESHOLD2 \* line 47
+      /\ evidence' = MyEvidence \union evidence
+      /\ round[p] + 1 \in Rounds
+      /\ StartRound(p, round[p] + 1)   
+      /\ UNCHANGED <<decision, lockedValue, lockedRound, validValue,
+                    validRound, msgsPropose, msgsPrevote, msgsPrecommit,
+                    localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                    beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+      /\ action' = "UponQuorumOfPrecommitsAny"
+                     
+\* lines 49-54        
+\* [PBTS-ALG-DECIDE.0]
+\* @type: (PROCESS) => Bool;
+UponProposalInPrecommitNoDecision(p) ==
+  /\ decision[p] = NilDecision \* line 49
+  /\ \E v \in ValidValues, t \in Timestamps (* line 50*) , r \in Rounds, vr \in RoundsOrNil:
+    /\ LET
+        \* @type: PROPMESSAGE; 
+        msg == 
+        [
+          type       |-> "PROPOSAL", 
+          src        |-> Proposer[r],
+          round      |-> r, 
+          proposal   |-> Proposal(v, t), 
+          validRound |-> vr
+        ] 
+       IN 
+     /\ msg \in msgsPropose[r] \* line 49
+     /\ p \in inspectedProposal[r]
+     /\ LET PV == { m \in msgsPrecommit[r]: m.id = Id(Proposal(v, t)) } IN
+       /\ Cardinality(PV) >= THRESHOLD2 \* line 49
+       /\ evidence' = PV \union {msg} \union evidence
+       /\ decision' = [decision EXCEPT ![p] = Decision(v, t, round[p])] \* update the decision, line 51
+    \* The original algorithm does not have 'DECIDED', but it increments the height.
+    \* We introduced 'DECIDED' here to prevent the process from changing its decision.
+       /\ endConsensus' = [endConsensus EXCEPT ![p] = localClock[p]]
+       /\ step' = [step EXCEPT ![p] = "DECIDED"]
+       /\ UNCHANGED <<round, lockedValue, lockedRound, validValue,
+                     validRound, msgsPropose, msgsPrevote, msgsPrecommit,
+                     localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                     beginConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+       /\ action' = "UponProposalInPrecommitNoDecision"
+                                                          
+\* the actions below are not essential for safety, but added for completeness
+
+\* lines 20-21 + 57-60
+\* @type: (PROCESS) => Bool;
+OnTimeoutPropose(p) ==
+  /\ step[p] = "PROPOSE"
+  /\ p /= Proposer[round[p]]
+  /\ BroadcastPrevote(p, round[p], NilProposal)
+  /\ step' = [step EXCEPT ![p] = "PREVOTE"]
+  /\ UNCHANGED <<round, lockedValue, lockedRound, validValue,
+                validRound, decision, evidence, msgsPropose, msgsPrecommit,
+                localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+  /\ action' = "OnTimeoutPropose"
+
+\* lines 44-46
+\* @type: (PROCESS) => Bool;
+OnQuorumOfNilPrevotes(p) ==
+  /\ step[p] = "PREVOTE"
+  /\ LET PV == { m \in msgsPrevote[round[p]]: m.id = Id(NilProposal) } IN
+    /\ Cardinality(PV) >= THRESHOLD2 \* line 36
+    /\ evidence' = PV \union evidence
+    /\ BroadcastPrecommit(p, round[p], Id(NilProposal))
+    /\ step' = [step EXCEPT ![p] = "PRECOMMIT"]
+    /\ UNCHANGED <<round, lockedValue, lockedRound, validValue,
+                  validRound, decision, msgsPropose, msgsPrevote,
+                  localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                  beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+    /\ action' = "OnQuorumOfNilPrevotes"
+
+\* lines 55-56
+\* @type: (PROCESS) => Bool;
+OnRoundCatchup(p) ==
+  \E r \in {rr \in Rounds: rr > round[p]}:
+    LET RoundMsgs == msgsPropose[r] \union msgsPrevote[r] \union msgsPrecommit[r] IN
+    \E MyEvidence \in SUBSET RoundMsgs:
+        LET Faster == { m.src: m \in MyEvidence } IN
+        /\ Cardinality(Faster) >= THRESHOLD1
+        /\ evidence' = MyEvidence \union evidence
+        /\ StartRound(p, r)
+        /\ UNCHANGED <<decision, lockedValue, lockedRound, validValue,
+                      validRound, msgsPropose, msgsPrevote, msgsPrecommit,
+                      localClock, realTime, receivedTimelyProposal, inspectedProposal,
+                      beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+        /\ action' = "OnRoundCatchup"
+
+
+(********************* PROTOCOL TRANSITIONS ******************************)
+\* advance the global clock
+\* @type: Bool;
+AdvanceRealTime == 
+    /\ realTime < MaxTimestamp
+    /\ realTime' = realTime + 1
+    /\ \/ /\ ~ClockDrift
+          /\ localClock' = [p \in Corr |-> localClock[p] + 1]  
+       \/ /\ ClockDrift
+          /\ UNCHANGED localClock
+    /\ UNCHANGED <<round, step, decision, lockedValue, lockedRound,
+                  validValue, validRound, evidence, msgsPropose, msgsPrevote, msgsPrecommit,
+                  localClock, receivedTimelyProposal, inspectedProposal,
+                  beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>> 
+    /\ action' = "AdvanceRealTime"
+    
+\* advance the local clock of node p
+\* @type: (PROCESS) => Bool;
+AdvanceLocalClock(p) ==
+    /\ localClock[p] < MaxTimestamp
+    /\ localClock' = [localClock EXCEPT ![p] = @ + 1]
+    /\ UNCHANGED <<round, step, decision, lockedValue, lockedRound,
+                  validValue, validRound, evidence, msgsPropose, msgsPrevote, msgsPrecommit,
+                  realTime, receivedTimelyProposal, inspectedProposal,
+                  beginConsensus, endConsensus, lastBeginConsensus, proposalTime, proposalReceivedTime>>
+    /\ action' = "AdvanceLocalClock"
+
+\* process timely messages
+\* @type: (PROCESS) => Bool;
+MessageProcessing(p) ==
+    \* start round
+    \/ InsertProposal(p)
+    \* reception step
+    \/ ReceiveProposal(p)
+    \* processing step
+    \/ UponProposalInPropose(p)
+    \/ UponProposalInProposeAndPrevote(p)
+    \/ UponQuorumOfPrevotesAny(p)
+    \/ UponProposalInPrevoteOrCommitAndPrevote(p)
+    \/ UponQuorumOfPrecommitsAny(p)
+    \/ UponProposalInPrecommitNoDecision(p)
+    \* the actions below are not essential for safety, but added for completeness
+    \/ OnTimeoutPropose(p)
+    \/ OnQuorumOfNilPrevotes(p)
+    \/ OnRoundCatchup(p)
+
+(*
+ * A system transition. In this specificatiom, the system may eventually deadlock,
+ * e.g., when all processes decide. This is expected behavior, as we focus on safety.
+ *)
+Next ==
+  \/ AdvanceRealTime
+  \/ /\ ClockDrift
+     /\ \E p \in Corr: AdvanceLocalClock(p)
+  \/ /\ SynchronizedLocalClocks
+     /\ \E p \in Corr: MessageProcessing(p)
+
+-----------------------------------------------------------------------------
+
+(*************************** INVARIANTS *************************************)
+
+\* [PBTS-INV-AGREEMENT.0]
+AgreementOnValue ==
+    \A p, q \in Corr:
+        /\ decision[p] /= NilDecision
+        /\ decision[q] /= NilDecision
+        => \E v \in ValidValues, t1 \in Timestamps, t2 \in Timestamps, r1 \in Rounds, r2 \in Rounds : 
+            /\ decision[p] = Decision(v, t1, r1)
+            /\ decision[q] = Decision(v, t2, r2)
+
+\* [PBTS-INV-TIME-AGR.0]
+AgreementOnTime ==
+    \A p, q \in Corr: 
+        \A v1 \in ValidValues, v2 \in ValidValues, t1 \in Timestamps, t2 \in Timestamps, r \in Rounds :
+            /\ decision[p] = Decision(v1, t1, r)
+            /\ decision[q] = Decision(v2, t2, r)
+            => t1 = t2
+
+\* [PBTS-CONSENSUS-TIME-VALID.0]
+ConsensusTimeValid ==
+    \A p \in Corr, t \in Timestamps : 
+    \* if a process decides on v and t
+    (\E v \in ValidValues, r \in Rounds : decision[p] = Decision(v, t, r))
+        \* then 
+        => /\ beginConsensus - Precision <= t 
+           /\ t < endConsensus[p] + Precision + Delay
+
+\* [PBTS-CONSENSUS-SAFE-VALID-CORR-PROP.0]
+ConsensusSafeValidCorrProp ==
+    \A v \in ValidValues, t \in Timestamps :
+        \* if the proposer in the first round is correct
+       (/\ Proposer[0] \in Corr
+        \* and there exists a process that decided on v, t 
+        /\ \E p \in Corr, r \in Rounds : decision[p] = Decision(v, t, r))
+            \* then t is between the minimal and maximal initial local time
+            => /\ beginConsensus <= t 
+               /\ t <= lastBeginConsensus
+
+\* [PBTS-CONSENSUS-REALTIME-VALID-CORR.0]
+ConsensusRealTimeValidCorr ==
+    \A t \in Timestamps, r \in Rounds :
+       (/\ \E p \in Corr, v \in ValidValues : decision[p] = Decision(v, t, r) 
+        /\ proposalTime[r] /= NilTimestamp)
+        => /\ proposalTime[r] - Accuracy < t
+           /\ t < proposalTime[r] + Accuracy
+
+\* [PBTS-CONSENSUS-REALTIME-VALID.0]
+ConsensusRealTimeValid ==
+    \A t \in Timestamps, r \in Rounds :
+       (\E p \in Corr, v \in ValidValues : decision[p] = Decision(v, t, r)) 
+        => /\ proposalReceivedTime[r] - Accuracy - Precision < t
+           /\ t < proposalReceivedTime[r] + Accuracy + Precision + Delay
+
+\* [PBTS-MSG-FAIR.0]
+BoundedDelay ==
+    \A r \in Rounds : 
+        (/\ proposalTime[r] /= NilTimestamp
+         /\ proposalTime[r] + Delay < realTime)
+            => inspectedProposal[r] = Corr
+
+\* [PBTS-CONSENSUS-TIME-LIVE.0]
+ConsensusTimeLive ==
+    \A r \in Rounds, p \in Corr : 
+       (/\ proposalTime[r] /= NilTimestamp
+        /\ proposalTime[r] + Delay < realTime 
+        /\ Proposer[r] \in Corr
+        /\ round[p] <= r)
+            => \E msg \in RoundProposals(r) : <<p, msg>> \in receivedTimelyProposal
+
+\* a conjunction of all invariants
+Inv ==
+    /\ AgreementOnValue 
+    /\ AgreementOnTime
+    /\ ConsensusTimeValid
+    /\ ConsensusSafeValidCorrProp
+    /\ ConsensusRealTimeValid
+    /\ ConsensusRealTimeValidCorr
+    /\ BoundedDelay
+
+Liveness ==
+    ConsensusTimeLive    
+
+=============================================================================    

--- a/spec/consensus/proposer-based-timestamp/tla/typedefs.tla
+++ b/spec/consensus/proposer-based-timestamp/tla/typedefs.tla
@@ -1,0 +1,40 @@
+-------------------- MODULE typedefs ---------------------------
+(*
+  @typeAlias: PROCESS = Str;
+  @typeAlias: VALUE = Str;
+  @typeAlias: STEP = Str;
+  @typeAlias: ROUND = Int;
+  @typeAlias: ACTION = Str;
+  @typeAlias: TRACE = Seq(Str);
+  @typeAlias: TIME = Int;
+  @typeAlias: PROPOSAL = <<VALUE, TIME>>;
+  @typeAlias: DECISION = <<VALUE, TIME, ROUND>>;
+  @typeAlias: RCVPROP = <<PROCESS, PROPMESSAGE>>;
+  @typeAlias: PROPMESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    proposal: PROPOSAL, 
+    validRound: ROUND
+  ];
+  @typeAlias: PREMESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    id: PROPOSAL
+  ];
+  @typeAlias: MESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    proposal: PROPOSAL, 
+    validRound: ROUND,
+    id: PROPOSAL
+  ];
+*)
+TypeAliases == TRUE
+
+=============================================================================

--- a/spec/consensus/proposer-based-timestamp/v1/pbts-algorithm_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/v1/pbts-algorithm_001_draft.md
@@ -1,6 +1,6 @@
-# Proposer-Based Time - Part II
+# PBTS: Protocol Specification (first draft)
 
-This specification is **OUTDATED**. Please refer to the [new version][v2].
+This specification is **OUTDATED**. Please refer to the [new version][algorithm].
 
 ## Updated Consensus Algorithm
 
@@ -152,16 +152,11 @@ upon ⟨PROPOSAL, h_p, r, (v,t), ∗⟩ from proposer(h_p, r) AND 2f + 1 ⟨PREC
 
 **All other rules remains unchanged.**
 
-Back to [main document][main].
+Back to [main document][main_v1].
 
-[main]: ./pbts_001_draft.md
+[main_v1]: ./pbts_001_draft.md
+
+[algorithm]: ../pbts-algorithm_002_draft.md
+[algorithm_v1]: ./pbts-algorithm_001_draft.md
 
 [arXiv]: https://arxiv.org/abs/1807.04938
-
-[tlatender]: https://github.com/tendermint/spec/blob/master/rust-spec/tendermint-accountability/README.md
-
-[bfttime]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/spec/consensus/bft-time.md
-
-[lcspec]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/rust-spec/lightclient/README.md
-
-[v2]: ./pbts-algorithm_002_draft.md

--- a/spec/consensus/proposer-based-timestamp/v1/pbts-sysmodel_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/v1/pbts-sysmodel_001_draft.md
@@ -1,6 +1,6 @@
-# Proposer-Based Time - Part I
+# PBTS: System Model and Properties (first draft)
 
-This specification is **OUTDATED**. Please refer to the [new version][v2].
+This specification is **OUTDATED**. Please refer to the [new version][sysmodel].
 
 ## System Model
 
@@ -183,20 +183,12 @@ Let `b` be a block with a valid commit that contains at least one `precommit` me
 
 > "triggered the `PRECOMMIT`" implies that the data in `m` and `b` are "matching", that is, `m` proposed the values that are actually stored in `b`.
 
-Back to [main document][main].
+Back to [main document][main_v1].
 
-[main]: ./pbts_001_draft.md
+[main_v1]: ./pbts_001_draft.md
+
+[algorithm_v1]: ./pbts-algorithm_001_draft.md
+
+[sysmodel]: ../pbts-sysmodel_002_draft.md
 
 [arXiv]: https://arxiv.org/abs/1807.04938
-
-[tlatender]: https://github.com/tendermint/spec/blob/master/rust-spec/tendermint-accountability/README.md
-
-[bfttime]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/spec/consensus/bft-time.md
-
-[lcspec]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/rust-spec/lightclient/README.md
-
-[algorithm]: ./pbts-algorithm_001_draft.md
-
-[sysmodel]: ./pbts-sysmodel_001_draft.md
-
-[v2]: ./pbts-sysmodel_002_draft.md

--- a/spec/consensus/proposer-based-timestamp/v1/pbts_001_draft.md
+++ b/spec/consensus/proposer-based-timestamp/v1/pbts_001_draft.md
@@ -1,6 +1,6 @@
 <!-- markdown-link-check-disable -->
 
-# Proposer-Based Time
+# Proposer-Based Time (first draft)
 
 ## Current BFTTime
 
@@ -251,22 +251,17 @@ For analyzing real-time safety (Point 5), we use a system parameter `ACCURACY`, 
 
 This specification describes the changes needed to be done to the Tendermint consensus algorithm as described in the [arXiv paper][arXiv] and the simplified specification in [TLA+][tlatender], and makes precise the underlying assumptions and the required properties.
 
-- [Part I - System Model and Properties][sysmodel]
-- [Part II - Protocol specification][algorithm]
+- [Part I - System Model and Properties][sysmodel_v1]
+- [Part II - Protocol specification][algorithm_v1]
 - [TLA+ Specification][proposertla]
 
-[arXiv]: https://arxiv.org/abs/1807.04938
+[algorithm_v1]: ./pbts-algorithm_001_draft.md
 
+[sysmodel_v1]: ./pbts-sysmodel_001_draft.md
+
+[proposertla]: ../tla/TendermintPBT_001_draft.tla
+
+[bfttime]: https://github.com/tendermint/spec/blob/master/spec/consensus/bft-time.md
 [tlatender]: https://github.com/tendermint/spec/blob/master/rust-spec/tendermint-accountability/README.md
-
-[bfttime]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/spec/consensus/bft-time.md
-
-[lcspec]: https://github.com/tendermint/spec/blob/439a5bcacb5ef6ef1118566d7b0cd68fff3553d4/rust-spec/lightclient/README.md
-
-[algorithm]: ./pbts-algorithm_002_draft.md
-
-[sysmodel]: ./pbts-sysmodel_002_draft.md
-
-[main]: ./pbts_001_draft.md
-
-[proposertla]: ./tla/TendermintPBT_001_draft.tla
+[lcspec]: https://github.com/tendermint/spec/tree/master/spec/light-client
+[arXiv]: https://arxiv.org/abs/1807.04938

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -37,8 +37,8 @@ The Tendermint blockchains consists of a short list of data types:
         - [ValidatorParams](#validatorparams)
         - [VersionParams](#versionparams)
         - [SynchronyParams](#synchronyparams)
+        - [TimeoutParams](#timeoutparams)
     - [Proof](#proof)
-
 
 ## Block
 
@@ -453,6 +453,17 @@ func SumTruncated(bz []byte) []byte {
 |---------------|--------|-------------------------------|--------------|
 | message_delay | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Bound for how long a proposal message may take to reach all validators on a newtork and still be considered valid. | 1            |
 | precision     | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Bound for how skewed a proposer's clock may be from any validator on the network while still producing valid proposals. | 2            |
+
+### TimeoutParams
+
+| Name          | Type   | Description                   | Field Number |
+|---------------|--------|-------------------------------|--------------|
+| propose | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Parameter that, along with propose_delta, configures the timeout for the propose step of the consensus algorithm. | 1 |
+| propose_delta | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Parameter that, along with propose, configures the timeout for the propose step of the consensus algorithm. | 2 |
+| vote | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)| Parameter that, along with vote_delta, configures the timeout for the prevote and precommit step of the consensus algorithm. | 3 |
+| vote_delta | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)| Parameter that, along with vote, configures the timeout for the prevote and precommit step of the consensus algorithm. | 4 |
+| commit | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Parameter that configures how long Tendermint will wait after receiving a quorum of precommits before beginning consensus for the next height.| 5 |
+| enable_commit_timeout_bypass | bool | Parameter that, if enabled, configures the node to proceed immediately to the next height once the node has received all precommits for a block, forgoing the commit timeout. |  6  |
 
 ## Proof
 

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -5,38 +5,39 @@ Here we describe the data structures in the Tendermint blockchain and the rules 
 The Tendermint blockchains consists of a short list of data types:
 
 - [Data Structures](#data-structures)
-  - [Block](#block)
-  - [Execution](#execution)
-  - [Header](#header)
-  - [Version](#version)
-  - [BlockID](#blockid)
-  - [PartSetHeader](#partsetheader)
-  - [Part](#part)
-  - [Time](#time)
-  - [Data](#data)
-  - [Commit](#commit)
-  - [CommitSig](#commitsig)
-  - [BlockIDFlag](#blockidflag)
-  - [Vote](#vote)
-  - [CanonicalVote](#canonicalvote)
-  - [Proposal](#proposal)
-  - [SignedMsgType](#signedmsgtype)
-  - [Signature](#signature)
-  - [EvidenceList](#evidencelist)
-  - [Evidence](#evidence)
-    - [DuplicateVoteEvidence](#duplicatevoteevidence)
-    - [LightClientAttackEvidence](#lightclientattackevidence)
-  - [LightBlock](#lightblock)
-  - [SignedHeader](#signedheader)
-  - [ValidatorSet](#validatorset)
-  - [Validator](#validator)
-  - [Address](#address)
-  - [ConsensusParams](#consensusparams)
-    - [BlockParams](#blockparams)
-    - [EvidenceParams](#evidenceparams)
-    - [ValidatorParams](#validatorparams)
-    - [VersionParams](#versionparams)
-  - [Proof](#proof)
+    - [Block](#block)
+    - [Execution](#execution)
+    - [Header](#header)
+    - [Version](#version)
+    - [BlockID](#blockid)
+    - [PartSetHeader](#partsetheader)
+    - [Part](#part)
+    - [Time](#time)
+    - [Data](#data)
+    - [Commit](#commit)
+    - [CommitSig](#commitsig)
+    - [BlockIDFlag](#blockidflag)
+    - [Vote](#vote)
+    - [CanonicalVote](#canonicalvote)
+    - [Proposal](#proposal)
+    - [SignedMsgType](#signedmsgtype)
+    - [Signature](#signature)
+    - [EvidenceList](#evidencelist)
+    - [Evidence](#evidence)
+        - [DuplicateVoteEvidence](#duplicatevoteevidence)
+        - [LightClientAttackEvidence](#lightclientattackevidence)
+    - [LightBlock](#lightblock)
+    - [SignedHeader](#signedheader)
+    - [ValidatorSet](#validatorset)
+    - [Validator](#validator)
+    - [Address](#address)
+    - [ConsensusParams](#consensusparams)
+        - [BlockParams](#blockparams)
+        - [EvidenceParams](#evidenceparams)
+        - [ValidatorParams](#validatorparams)
+        - [VersionParams](#versionparams)
+        - [SynchronyParams](#synchronyparams)
+    - [Proof](#proof)
 
 
 ## Block
@@ -445,6 +446,13 @@ func SumTruncated(bz []byte) []byte {
 | Name        | Type   | Description                   | Field Number |
 |-------------|--------|-------------------------------|--------------|
 | app_version | uint64 | The ABCI application version. | 1            |
+
+### SynchronyParams
+
+| Name          | Type   | Description                   | Field Number |
+|---------------|--------|-------------------------------|--------------|
+| message_delay | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Bound for how long a proposal message may take to reach all validators on a newtork and still be considered valid. | 1            |
+| precision     | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Bound for how skewed a proposer's clock may be from any validator on the network while still producing valid proposals. | 2            |
 
 ## Proof
 

--- a/spec/light-client/accountability/MC_n4_f1.tla
+++ b/spec/light-client/accountability/MC_n4_f1.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n4_f1 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action 
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3"},

--- a/spec/light-client/accountability/MC_n4_f2.tla
+++ b/spec/light-client/accountability/MC_n4_f2.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n4_f2 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2"},

--- a/spec/light-client/accountability/MC_n4_f2_amnesia.tla
+++ b/spec/light-client/accountability/MC_n4_f2_amnesia.tla
@@ -1,19 +1,41 @@
 ---------------------- MODULE MC_n4_f2_amnesia -------------------------------
 EXTENDS Sequences
 
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 \* the variable declared in TendermintAccTrace3
 VARIABLE
+  \* @type: TRACE;
   toReplay
-
-\* old apalache annotations, fix with the new release
-a <: b == a  
 
 INSTANCE TendermintAccTrace_004_draft WITH
   Corr <- {"c1", "c2"},
@@ -31,7 +53,7 @@ INSTANCE TendermintAccTrace_004_draft WITH
     "UponProposalInPropose",
     "UponProposalInPrevoteOrCommitAndPrevote",
     "UponProposalInPrecommitNoDecision"
-  >> <: Seq(STRING)
+  >>
 
 \* run Apalache with --cinit=ConstInit
 ConstInit == \* the proposer is arbitrary -- works for safety

--- a/spec/light-client/accountability/MC_n4_f3.tla
+++ b/spec/light-client/accountability/MC_n4_f3.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n4_f3 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1"},

--- a/spec/light-client/accountability/MC_n5_f1.tla
+++ b/spec/light-client/accountability/MC_n5_f1.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n5_f1 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3", "c4"},

--- a/spec/light-client/accountability/MC_n5_f2.tla
+++ b/spec/light-client/accountability/MC_n5_f2.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n5_f2 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3"},

--- a/spec/light-client/accountability/MC_n6_f1.tla
+++ b/spec/light-client/accountability/MC_n6_f1.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n6_f1 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action 
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3", "c4", "c5"},

--- a/spec/light-client/accountability/TendermintAccDebug_004_draft.tla
+++ b/spec/light-client/accountability/TendermintAccDebug_004_draft.tla
@@ -19,6 +19,7 @@ NFaultyPrecommits == 6  \* the number of injected faulty PRECOMMIT messages
 \* rounds to sets of messages.
 \* Importantly, there will be exactly k messages in the image of msgFun.
 \* We use this action to produce k faults in an initial state.
+\* @type: (ROUND -> Set(MESSAGE), Set(MESSAGE), Int) => Bool;
 ProduceFaults(msgFun, From, k) ==
     \E f \in [1..k -> From]:
         msgFun = [r \in Rounds |-> {m \in {f[i]: i \in 1..k}: m.round = r}]
@@ -50,14 +51,14 @@ InitFewFaults ==
     /\ validValue = [p \in Corr |-> NilValue]
     /\ validRound = [p \in Corr |-> NilRound]
     /\ ProduceFaults(msgsPrevote',
-                     SetOfMsgs([type: {"PREVOTE"}, src: Faulty, round: Rounds, id: Values]),
+                     [type: {"PREVOTE"}, src: Faulty, round: Rounds, id: Values],
                      NFaultyPrevotes)
     /\ ProduceFaults(msgsPrecommit',
-                     SetOfMsgs([type: {"PRECOMMIT"}, src: Faulty, round: Rounds, id: Values]),
+                     [type: {"PRECOMMIT"}, src: Faulty, round: Rounds, id: Values],
                      NFaultyPrecommits)
     /\ ProduceFaults(msgsPropose',
-                     SetOfMsgs([type: {"PROPOSAL"}, src: Faulty, round: Rounds,
-                                proposal: Values, validRound: Rounds \cup {NilRound}]),
+                     [type: {"PROPOSAL"}, src: Faulty, round: Rounds,
+                                proposal: Values, validRound: Rounds \cup {NilRound}],
                      NFaultyProposals)
     /\ evidence = EmptyMsgSet
 

--- a/spec/light-client/accountability/TendermintAccInv_004_draft.tla
+++ b/spec/light-client/accountability/TendermintAccInv_004_draft.tla
@@ -13,24 +13,27 @@ EXTENDS TendermintAcc_004_draft
   
 (************************** TYPE INVARIANT ***********************************)
 (* first, we define the sets of all potential messages *)
+\* @type: Set(PROPMESSAGE);
 AllProposals == 
-  SetOfMsgs([type: {"PROPOSAL"},
-             src: AllProcs,
-             round: Rounds,
-             proposal: ValuesOrNil,
-             validRound: RoundsOrNil])
+  [type: {"PROPOSAL"},
+   src: AllProcs,
+   round: Rounds,
+   proposal: ValuesOrNil,
+   validRound: RoundsOrNil]
   
+\* @type: Set(PREMESSAGE);
 AllPrevotes ==
-  SetOfMsgs([type: {"PREVOTE"},
-             src: AllProcs,
-             round: Rounds,
-             id: ValuesOrNil])
+  [type: {"PREVOTE"},
+   src: AllProcs,
+   round: Rounds,
+   id: ValuesOrNil]
 
+\* @type: Set(PREMESSAGE);
 AllPrecommits ==
-  SetOfMsgs([type: {"PRECOMMIT"},
-             src: AllProcs,
-             round: Rounds,
-             id: ValuesOrNil])
+  [type: {"PRECOMMIT"},
+   src: AllProcs,
+   round: Rounds,
+   id: ValuesOrNil]
 
 (* the standard type invariant -- importantly, it is inductive *)
 TypeOK ==
@@ -226,7 +229,7 @@ LatestPrecommitHasLockedRound(p) ==
   LET pPrecommits ==
     {mm \in UNION { msgsPrecommit[r]: r \in Rounds }: mm.src = p /\ mm.id /= NilValue }
   IN
-  pPrecommits /= {} <: {MT}
+  pPrecommits /= {}
     => LET latest ==
          CHOOSE m \in pPrecommits:
            \A m2 \in pPrecommits:
@@ -242,6 +245,7 @@ AllLatestPrecommitHasLockedRound ==
 \* Every correct process sends only one value or NilValue.
 \* This test has quantifier alternation -- a threat to all decision procedures.
 \* Luckily, the sets Corr and ValidValues are small.
+\* @type: (ROUND, ROUND -> Set(PREMESSAGE)) => Bool;
 NoEquivocationByCorrect(r, msgs) ==
   \A p \in Corr:
     \E v \in ValidValues \union {NilValue}:
@@ -250,6 +254,7 @@ NoEquivocationByCorrect(r, msgs) ==
         \/ m.id = v
 
 \* a proposer nevers sends two values
+\* @type: (ROUND, ROUND -> Set(PROPMESSAGE)) => Bool;
 ProposalsByProposer(r, msgs) ==
   \* if the proposer is not faulty, it sends only one value
   \E v \in ValidValues:
@@ -264,6 +269,7 @@ AllNoEquivocationByCorrect ==
     /\ NoEquivocationByCorrect(r, msgsPrecommit)    
 
 \* construct the set of the message senders
+\* @type: (Set(MESSAGE)) => Set(PROCESS);
 Senders(M) == { m.src: m \in M }
 
 \* The final piece by Josef Widder:

--- a/spec/light-client/accountability/TendermintAccTrace_004_draft.tla
+++ b/spec/light-client/accountability/TendermintAccTrace_004_draft.tla
@@ -13,9 +13,13 @@ EXTENDS Sequences, Apalache, TendermintAcc_004_draft
 
 \* a sequence of action names that should appear in the given order,
 \* excluding "Init"
-CONSTANT Trace
+CONSTANT 
+  \* @type: TRACE;
+  Trace
 
-VARIABLE toReplay
+VARIABLE 
+  \* @type: TRACE;
+  toReplay
 
 TraceInit ==
     /\ toReplay = Trace

--- a/spec/light-client/accountability/typedefs.tla
+++ b/spec/light-client/accountability/typedefs.tla
@@ -1,0 +1,36 @@
+-------------------- MODULE typedefs ---------------------------
+(*
+  @typeAlias: PROCESS = Str;
+  @typeAlias: VALUE = Str;
+  @typeAlias: STEP = Str;
+  @typeAlias: ROUND = Int;
+  @typeAlias: ACTION = Str;
+  @typeAlias: TRACE = Seq(Str);
+  @typeAlias: PROPMESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    proposal: VALUE, 
+    validRound: ROUND
+  ];
+  @typeAlias: PREMESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    id: VALUE
+  ];
+  @typeAlias: MESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    proposal: VALUE, 
+    validRound: ROUND,
+    id: VALUE
+  ];
+*)
+TypeAliases == TRUE
+
+=============================================================================

--- a/spec/p2p/messages/evidence.md
+++ b/spec/p2p/messages/evidence.md
@@ -14,10 +14,10 @@ Evidence has one channel. The channel identifier is listed below.
 
 ## Message Types
 
-### EvidenceList
+### Evidence
 
-EvidenceList consists of a list of verified evidence. This evidence will already have been propagated throughout the network. EvidenceList is used in two places, as a p2p message and within the block [block](../../core/data_structures.md#block) as well.
+Verified evidence that has already been propagated throughout the network. This evidence will appear within the EvidenceList struct of a [block](../../core/data_structures.md#block) as well.
 
 | Name     | Type                                                        | Description            | Field Number |
 |----------|-------------------------------------------------------------|------------------------|--------------|
-| evidence | repeated [Evidence](../../core/data_structures.md#evidence) | List of valid evidence | 1            |
+| evidence | [Evidence](../../core/data_structures.md#evidence) | Valid evidence | 1            |


### PR DESCRIPTION
After this PR the "methods" section of ABCI++ are in sync with the types in proto/tendermint/abci/

This is addressing issue #386 

I am seeking to merge to sergio/abci++ (newly created branch) as merging with master would break anyone running "make proto-gen" from Tendermint Go repo.

In order to test the changes, I've adapted  "scripts/protocgen.sh" so that "make proto-gen" picks up my PR branch.
