### PR TITLE
Updated Apalache type annotations

### DIFF
--- a/spec/light-client/accountability/MC_n4_f1.tla
+++ b/spec/light-client/accountability/MC_n4_f1.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n4_f1 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action 
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3"},

--- a/spec/light-client/accountability/MC_n4_f2.tla
+++ b/spec/light-client/accountability/MC_n4_f2.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n4_f2 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2"},

--- a/spec/light-client/accountability/MC_n4_f2_amnesia.tla
+++ b/spec/light-client/accountability/MC_n4_f2_amnesia.tla
@@ -1,19 +1,41 @@
 ---------------------- MODULE MC_n4_f2_amnesia -------------------------------
 EXTENDS Sequences
 
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 \* the variable declared in TendermintAccTrace3
 VARIABLE
+  \* @type: TRACE;
   toReplay
-
-\* old apalache annotations, fix with the new release
-a <: b == a  
 
 INSTANCE TendermintAccTrace_004_draft WITH
   Corr <- {"c1", "c2"},
@@ -31,7 +53,7 @@ INSTANCE TendermintAccTrace_004_draft WITH
     "UponProposalInPropose",
     "UponProposalInPrevoteOrCommitAndPrevote",
     "UponProposalInPrecommitNoDecision"
-  >> <: Seq(STRING)
+  >>
 
 \* run Apalache with --cinit=ConstInit
 ConstInit == \* the proposer is arbitrary -- works for safety

--- a/spec/light-client/accountability/MC_n4_f3.tla
+++ b/spec/light-client/accountability/MC_n4_f3.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n4_f3 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1"},

--- a/spec/light-client/accountability/MC_n5_f1.tla
+++ b/spec/light-client/accountability/MC_n5_f1.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n5_f1 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3", "c4"},

--- a/spec/light-client/accountability/MC_n5_f2.tla
+++ b/spec/light-client/accountability/MC_n5_f2.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n5_f2 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3"},

--- a/spec/light-client/accountability/MC_n6_f1.tla
+++ b/spec/light-client/accountability/MC_n6_f1.tla
@@ -1,10 +1,34 @@
 ----------------------------- MODULE MC_n6_f1 -------------------------------
-CONSTANT Proposer \* the proposer function from 0..NRounds to 1..N
+CONSTANT 
+  \* @type: ROUND -> PROCESS;
+  Proposer
 
 \* the variables declared in TendermintAcc3
 VARIABLES
-  round, step, decision, lockedValue, lockedRound, validValue, validRound,
-  msgsPropose, msgsPrevote, msgsPrecommit, evidence, action 
+  \* @type: PROCESS -> ROUND;
+  round,  
+  \* @type: PROCESS -> STEP;
+  step,   
+  \* @type: PROCESS -> VALUE;
+  decision,
+  \* @type: PROCESS -> VALUE;
+  lockedValue, 
+  \* @type: PROCESS -> ROUND;
+  lockedRound, 
+  \* @type: PROCESS -> VALUE;
+  validValue,  
+  \* @type: PROCESS -> ROUND;
+  validRound,   
+  \* @type: ROUND -> Set(PROPMESSAGE);
+  msgsPropose, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrevote, 
+  \* @type: ROUND -> Set(PREMESSAGE);
+  msgsPrecommit, 
+  \* @type: Set(MESSAGE);
+  evidence, 
+  \* @type: ACTION;
+  action 
 
 INSTANCE TendermintAccDebug_004_draft WITH
   Corr <- {"c1", "c2", "c3", "c4", "c5"},

--- a/spec/light-client/accountability/TendermintAccDebug_004_draft.tla
+++ b/spec/light-client/accountability/TendermintAccDebug_004_draft.tla
@@ -19,6 +19,7 @@ NFaultyPrecommits == 6  \* the number of injected faulty PRECOMMIT messages
 \* rounds to sets of messages.
 \* Importantly, there will be exactly k messages in the image of msgFun.
 \* We use this action to produce k faults in an initial state.
+\* @type: (ROUND -> Set(MESSAGE), Set(MESSAGE), Int) => Bool;
 ProduceFaults(msgFun, From, k) ==
     \E f \in [1..k -> From]:
         msgFun = [r \in Rounds |-> {m \in {f[i]: i \in 1..k}: m.round = r}]
@@ -50,14 +51,14 @@ InitFewFaults ==
     /\ validValue = [p \in Corr |-> NilValue]
     /\ validRound = [p \in Corr |-> NilRound]
     /\ ProduceFaults(msgsPrevote',
-                     SetOfMsgs([type: {"PREVOTE"}, src: Faulty, round: Rounds, id: Values]),
+                     [type: {"PREVOTE"}, src: Faulty, round: Rounds, id: Values],
                      NFaultyPrevotes)
     /\ ProduceFaults(msgsPrecommit',
-                     SetOfMsgs([type: {"PRECOMMIT"}, src: Faulty, round: Rounds, id: Values]),
+                     [type: {"PRECOMMIT"}, src: Faulty, round: Rounds, id: Values],
                      NFaultyPrecommits)
     /\ ProduceFaults(msgsPropose',
-                     SetOfMsgs([type: {"PROPOSAL"}, src: Faulty, round: Rounds,
-                                proposal: Values, validRound: Rounds \cup {NilRound}]),
+                     [type: {"PROPOSAL"}, src: Faulty, round: Rounds,
+                                proposal: Values, validRound: Rounds \cup {NilRound}],
                      NFaultyProposals)
     /\ evidence = EmptyMsgSet
 

--- a/spec/light-client/accountability/TendermintAccInv_004_draft.tla
+++ b/spec/light-client/accountability/TendermintAccInv_004_draft.tla
@@ -13,24 +13,27 @@ EXTENDS TendermintAcc_004_draft
   
 (************************** TYPE INVARIANT ***********************************)
 (* first, we define the sets of all potential messages *)
+\* @type: Set(PROPMESSAGE);
 AllProposals == 
-  SetOfMsgs([type: {"PROPOSAL"},
-             src: AllProcs,
-             round: Rounds,
-             proposal: ValuesOrNil,
-             validRound: RoundsOrNil])
+  [type: {"PROPOSAL"},
+   src: AllProcs,
+   round: Rounds,
+   proposal: ValuesOrNil,
+   validRound: RoundsOrNil]
   
+\* @type: Set(PREMESSAGE);
 AllPrevotes ==
-  SetOfMsgs([type: {"PREVOTE"},
-             src: AllProcs,
-             round: Rounds,
-             id: ValuesOrNil])
+  [type: {"PREVOTE"},
+   src: AllProcs,
+   round: Rounds,
+   id: ValuesOrNil]
 
+\* @type: Set(PREMESSAGE);
 AllPrecommits ==
-  SetOfMsgs([type: {"PRECOMMIT"},
-             src: AllProcs,
-             round: Rounds,
-             id: ValuesOrNil])
+  [type: {"PRECOMMIT"},
+   src: AllProcs,
+   round: Rounds,
+   id: ValuesOrNil]
 
 (* the standard type invariant -- importantly, it is inductive *)
 TypeOK ==
@@ -226,7 +229,7 @@ LatestPrecommitHasLockedRound(p) ==
   LET pPrecommits ==
     {mm \in UNION { msgsPrecommit[r]: r \in Rounds }: mm.src = p /\ mm.id /= NilValue }
   IN
-  pPrecommits /= {} <: {MT}
+  pPrecommits /= {}
     => LET latest ==
          CHOOSE m \in pPrecommits:
            \A m2 \in pPrecommits:
@@ -242,6 +245,7 @@ AllLatestPrecommitHasLockedRound ==
 \* Every correct process sends only one value or NilValue.
 \* This test has quantifier alternation -- a threat to all decision procedures.
 \* Luckily, the sets Corr and ValidValues are small.
+\* @type: (ROUND, ROUND -> Set(PREMESSAGE)) => Bool;
 NoEquivocationByCorrect(r, msgs) ==
   \A p \in Corr:
     \E v \in ValidValues \union {NilValue}:
@@ -250,6 +254,7 @@ NoEquivocationByCorrect(r, msgs) ==
         \/ m.id = v
 
 \* a proposer nevers sends two values
+\* @type: (ROUND, ROUND -> Set(PROPMESSAGE)) => Bool;
 ProposalsByProposer(r, msgs) ==
   \* if the proposer is not faulty, it sends only one value
   \E v \in ValidValues:
@@ -264,6 +269,7 @@ AllNoEquivocationByCorrect ==
     /\ NoEquivocationByCorrect(r, msgsPrecommit)    
 
 \* construct the set of the message senders
+\* @type: (Set(MESSAGE)) => Set(PROCESS);
 Senders(M) == { m.src: m \in M }
 
 \* The final piece by Josef Widder:

--- a/spec/light-client/accountability/TendermintAccTrace_004_draft.tla
+++ b/spec/light-client/accountability/TendermintAccTrace_004_draft.tla
@@ -13,9 +13,13 @@ EXTENDS Sequences, Apalache, TendermintAcc_004_draft
 
 \* a sequence of action names that should appear in the given order,
 \* excluding "Init"
-CONSTANT Trace
+CONSTANT 
+  \* @type: TRACE;
+  Trace
 
-VARIABLE toReplay
+VARIABLE 
+  \* @type: TRACE;
+  toReplay
 
 TraceInit ==
     /\ toReplay = Trace

--- a/spec/light-client/accountability/typedefs.tla
+++ b/spec/light-client/accountability/typedefs.tla
@@ -1,0 +1,36 @@
+-------------------- MODULE typedefs ---------------------------
+(*
+  @typeAlias: PROCESS = Str;
+  @typeAlias: VALUE = Str;
+  @typeAlias: STEP = Str;
+  @typeAlias: ROUND = Int;
+  @typeAlias: ACTION = Str;
+  @typeAlias: TRACE = Seq(Str);
+  @typeAlias: PROPMESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    proposal: VALUE, 
+    validRound: ROUND
+  ];
+  @typeAlias: PREMESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    id: VALUE
+  ];
+  @typeAlias: MESSAGE = 
+  [
+    type: STEP, 
+    src: PROCESS, 
+    round: ROUND,
+    proposal: VALUE, 
+    validRound: ROUND,
+    id: VALUE
+  ];
+*)
+TypeAliases == TRUE
+
+=============================================================================


### PR DESCRIPTION
The specifications were using the old format of Apalache type annotations. This PR migrates them to the new format (but does not extend the specifications otherwise).