### PR TITLE
Add the newly defined timeout parameters to the consensus parameters

### DIFF
--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -130,7 +130,7 @@ message TimeoutParams {
   // enable_commit_timeout_bypass configures the node to proceed immediately to
   // the next height once the node has received all precommits for a block, forgoing
   // the remaining commit timeout.
-  // Setting enable_commit_timeout_bypass = false configures Tendermint to wait
+  // Setting enable_commit_timeout_bypass false (the default) causes Tendermint to wait
   // for the full commit.
   bool enable_commit_timeout_bypass = 6;
 }

--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -86,12 +86,11 @@ message SynchronyParams {
 // TimeoutParams configure the timeouts for the steps of the Tendermint consensus algorithm.
 message TimeoutParams {
 
-  // propose along with propose_delta configure the timeout for the propose step of
-  // the Tendermint consensus algorithm.
-  //
-  // propose configures the initial timeout and propose_delta configures by how much the timeout
-  // grows each subsequent round. For the first round, this propose timeout is used
-  // and for every subsequent round, the timeout grows by propose_delta.
+  // These fields configure the timeouts for the propose step of the Tendermint
+  // consensus algorithm: propose is the initial timeout and propose_delta
+  // determines how much the timeout grows in subsequent rounds.
+  // For the first round, this propose timeout is used and for every subsequent
+  // round, the timeout grows by propose_delta.
   //
   // For example:
   // With propose = 10ms, propose_delta = 5ms, the first round's propose phase

--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -75,17 +75,14 @@ message HashedParams {
 message SynchronyParams {
   // message_delay bounds how long a proposal message may take to reach all validators on a newtork
   // and still be considered valid.
-  google.protobuf.Duration message_delay = 1
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration message_delay = 1 [(gogoproto.stdduration) = true];
   // precision bounds how skewed a proposer's clock may be from any validator
   // on the network while still producing valid proposals.
-  google.protobuf.Duration precision = 2
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration precision = 2 [(gogoproto.stdduration) = true];
 }
 
 // TimeoutParams configure the timeouts for the steps of the Tendermint consensus algorithm.
 message TimeoutParams {
-
   // These fields configure the timeouts for the propose step of the Tendermint
   // consensus algorithm: propose is the initial timeout and propose_delta
   // determines how much the timeout grows in subsequent rounds.
@@ -99,10 +96,8 @@ message TimeoutParams {
   // If a node waiting for a proposal message does not receive one matching its
   // current height and round before this timeout, the node will issue a
   // nil prevote for the round and advance to the next step.
-  google.protobuf.Duration propose = 1
-      [(gogoproto.stdduration) = true];
-  google.protobuf.Duration = propose_delta = 2
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration propose       = 1 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration propose_delta = 2 [(gogoproto.stdduration) = true];
 
   // vote along with vote_delta configure the timeout for both of the prevote and
   // precommit steps of the Tendermint consensus algorithm.
@@ -115,16 +110,13 @@ message TimeoutParams {
   // procced to the next step of the consensus algorithm. If Tendermint receives
   // all of the remaining votes before the end of the timeout, it will proceed
   // to the next step immediately.
-  google.protobuf.Duration vote = 3
-      [(gogoproto.stdduration) = true];
-  google.protobuf.Duration = vote_delta = 4
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration vote       = 3 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration vote_delta = 4 [(gogoproto.stdduration) = true];
 
   // commit configures how long Tendermint will wait after receiving a quorum of
   // precommits before beginning consensus for the next height. This can be
   // used to allow slow precommits to arrive for inclusion in the next height before progressing.
-  google.protobuf.Duration commit = 5
-      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration commit = 5 [(gogoproto.stdduration) = true];
 
   // enable_commit_timeout_bypass configures the node to proceed immediately to
   // the next height once the node has received all precommits for a block, forgoing

--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -14,6 +14,7 @@ message ConsensusParams {
   ValidatorParams validator = 3;
   VersionParams   version   = 4;
   SynchronyParams synchrony = 5;
+  TimeoutParams   timeout   = 6;
 }
 
 // BlockParams contains limits on the block size.
@@ -80,4 +81,56 @@ message SynchronyParams {
   // on the network while still producing valid proposals.
   google.protobuf.Duration precision = 2
       [(gogoproto.stdduration) = true];
+}
+
+// TimeoutParams configure the timeouts for the steps of the Tendermint consensus algorithm.
+message TimeoutParams {
+
+  // propose along with propose_delta configure the timeout for the propose step of
+  // the Tendermint consensus algorithm.
+  //
+  // propose configures the initial timeout and propose_delta configures by how much the timeout
+  // grows each subsequent round. For the first round, this propose timeout is used
+  // and for every subsequent round, the timeout grows by propose_delta.
+  //
+  // For example:
+  // With propose = 10ms, propose_delta = 5ms, the first round's propose phase
+  // timeout would be 10ms, the second round's would be 15ms, the third 20ms and so on.
+  //
+  // If a node waiting for a proposal message does not receive one matching its
+  // current height and round before this timeout, the node will issue a
+  // nil prevote for the round and advance to the next step.
+  google.protobuf.Duration propose = 1
+      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration = propose_delta = 2
+      [(gogoproto.stdduration) = true];
+
+  // vote along with vote_delta configure the timeout for both of the prevote and
+  // precommit steps of the Tendermint consensus algorithm.
+  //
+  // These parameters influence the vote step timeouts in the the same way that
+  // the propose and propose_delta parameters do to the proposal step.
+  //
+  // The vote timeout does not begin until a quorum of votes has been received. Once
+  // a quorum of votes has been seen and this timeout elapses, Tendermint will
+  // procced to the next step of the consensus algorithm. If Tendermint receives
+  // all of the remaining votes before the end of the timeout, it will proceed
+  // to the next step immediately.
+  google.protobuf.Duration vote = 3
+      [(gogoproto.stdduration) = true];
+  google.protobuf.Duration = vote_delta = 4
+      [(gogoproto.stdduration) = true];
+
+  // commit configures how long Tendermint will wait after receiving a quorum of
+  // precommits before beginning consensus for the next height. This can be
+  // used to allow slow precommits to arrive for inclusion in the next height before progressing.
+  google.protobuf.Duration commit = 5
+      [(gogoproto.stdduration) = true];
+
+  // enable_commit_timeout_bypass configures the node to proceed immediately to
+  // the next height once the node has received all precommits for a block, forgoing
+  // the remaining commit timeout.
+  // Setting enable_commit_timeout_bypass = false configures Tendermint to wait
+  // for the full commit.
+  bool enable_commit_timeout_bypass = 6;
 }

--- a/spec/abci/abci.md
+++ b/spec/abci/abci.md
@@ -737,7 +737,8 @@ Most of the data structures used in ABCI are shared [common data structures](../
     | evidence  | [EvidenceParams](../core/data_structures.md#evidenceparams)   | Parameters limiting the validity of evidence of byzantine behaviour.         | 2            |
     | validator | [ValidatorParams](../core/data_structures.md#validatorparams) | Parameters limiting the types of public keys validators can use.             | 3            |
     | version   | [VersionsParams](../core/data_structures.md#versionparams)       | The ABCI application version.                                                | 4            |
-    | synchrony  | [SynchronyParams](../core/data_structures.md#synchronyparams)   | Parameters that determine the bounds under which a proposed block's timestamp is considered valid.                                                | 4            |
+    | synchrony | [SynchronyParams](../core/data_structures.md#synchronyparams)   | Parameters that determine the bounds under which a proposed block's timestamp is considered valid.   | 5            |
+    | timeout   | [TimeoutParams](../core/data_structures.md#timeoutparams)   | Parameters that configure the timeouts for the steps of the Tendermint consensus algorithm. | 6            |
 
 ### ProofOps
 

--- a/spec/core/data_structures.md
+++ b/spec/core/data_structures.md
@@ -37,8 +37,8 @@ The Tendermint blockchains consists of a short list of data types:
         - [ValidatorParams](#validatorparams)
         - [VersionParams](#versionparams)
         - [SynchronyParams](#synchronyparams)
+        - [TimeoutParams](#timeoutparams)
     - [Proof](#proof)
-
 
 ## Block
 
@@ -453,6 +453,17 @@ func SumTruncated(bz []byte) []byte {
 |---------------|--------|-------------------------------|--------------|
 | message_delay | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Bound for how long a proposal message may take to reach all validators on a newtork and still be considered valid. | 1            |
 | precision     | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Bound for how skewed a proposer's clock may be from any validator on the network while still producing valid proposals. | 2            |
+
+### TimeoutParams
+
+| Name          | Type   | Description                   | Field Number |
+|---------------|--------|-------------------------------|--------------|
+| propose | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Parameter that, along with propose_delta, configures the timeout for the propose step of the consensus algorithm. | 1 |
+| propose_delta | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Parameter that, along with propose, configures the timeout for the propose step of the consensus algorithm. | 2 |
+| vote | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)| Parameter that, along with vote_delta, configures the timeout for the prevote and precommit step of the consensus algorithm. | 3 |
+| vote_delta | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)| Parameter that, along with vote, configures the timeout for the prevote and precommit step of the consensus algorithm. | 4 |
+| commit | [google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration) | Parameter that configures how long Tendermint will wait after receiving a quorum of precommits before beginning consensus for the next height.| 5 |
+| enable_commit_timeout_bypass | bool | Parameter that, if enabled, configures the node to proceed immediately to the next height once the node has received all precommits for a block, forgoing the commit timeout. |  6  |
 
 ## Proof
 


### PR DESCRIPTION
This pull request adds the `TimeoutParams` that were defined in [ADR-74](https://github.com/tendermint/tendermint/blob/master/docs/architecture/adr-074-timeout-params.md) to the consensus parameters.

The main value of having these parameters in the consensus parameters is to enable the application to more reliably manage their values. The enforcement of their values across all validators is much less important than their equality and configurability by applications.

Closes: https://github.com/tendermint/tendermint/issues/7759