### PR TITLE
make consensus parameters non nullable

### DIFF
--- a/proto/tendermint/types/params.proto
+++ b/proto/tendermint/types/params.proto
@@ -40,8 +40,7 @@ message EvidenceParams {
   // It should correspond with an app's "unbonding period" or other similar
   // mechanism for handling [Nothing-At-Stake
   // attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
-  google.protobuf.Duration max_age_duration = 2
-      [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  google.protobuf.Duration max_age_duration = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
   // This sets the maximum size of total evidence in bytes that can be committed
   // in a single block. and should fall comfortably under the max block bytes.
@@ -75,10 +74,10 @@ message HashedParams {
 message SynchronyParams {
   // message_delay bounds how long a proposal message may take to reach all validators on a newtork
   // and still be considered valid.
-  google.protobuf.Duration message_delay = 1 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration message_delay = 1 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
   // precision bounds how skewed a proposer's clock may be from any validator
   // on the network while still producing valid proposals.
-  google.protobuf.Duration precision = 2 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration precision = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 }
 
 // TimeoutParams configure the timeouts for the steps of the Tendermint consensus algorithm.
@@ -96,8 +95,8 @@ message TimeoutParams {
   // If a node waiting for a proposal message does not receive one matching its
   // current height and round before this timeout, the node will issue a
   // nil prevote for the round and advance to the next step.
-  google.protobuf.Duration propose       = 1 [(gogoproto.stdduration) = true];
-  google.protobuf.Duration propose_delta = 2 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration propose       = 1 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  google.protobuf.Duration propose_delta = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
   // vote along with vote_delta configure the timeout for both of the prevote and
   // precommit steps of the Tendermint consensus algorithm.
@@ -110,13 +109,13 @@ message TimeoutParams {
   // procced to the next step of the consensus algorithm. If Tendermint receives
   // all of the remaining votes before the end of the timeout, it will proceed
   // to the next step immediately.
-  google.protobuf.Duration vote       = 3 [(gogoproto.stdduration) = true];
-  google.protobuf.Duration vote_delta = 4 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration vote       = 3 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  google.protobuf.Duration vote_delta = 4 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
   // commit configures how long Tendermint will wait after receiving a quorum of
   // precommits before beginning consensus for the next height. This can be
   // used to allow slow precommits to arrive for inclusion in the next height before progressing.
-  google.protobuf.Duration commit = 5 [(gogoproto.stdduration) = true];
+  google.protobuf.Duration commit = 5 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
   // enable_commit_timeout_bypass configures the node to proceed immediately to
   // the next height once the node has received all precommits for a block, forgoing


### PR DESCRIPTION
Allow these parameters to be pointers in the Go code doesn't actually buy us much: these parameters must be set and will be set on application startup, so allowing them to be nil only leaves a possible panic without much gain.